### PR TITLE
fix: register new agents and skills in plugin.json

### DIFF
--- a/packages/popkit-dev/.claude-plugin/plugin.json
+++ b/packages/popkit-dev/.claude-plugin/plugin.json
@@ -30,7 +30,17 @@
     "./skills/pop-finish-branch",
     "./skills/pop-worktrees",
     "./skills/pop-morning",
-    "./skills/pop-nightly"
+    "./skills/pop-nightly",
+    "./skills/pop-complexity-analyzer",
+    "./skills/pop-changelog-automation"
   ],
-  "agents": []
+  "agents": [
+    "./agents/feature-workflow/code-architect",
+    "./agents/feature-workflow/code-explorer",
+    "./agents/tier-1-always-active/code-reviewer",
+    "./agents/tier-1-always-active/refactoring-expert",
+    "./agents/tier-2-on-demand/rapid-prototyper",
+    "./agents/tier-2-on-demand/prd-parser",
+    "./agents/tier-2-on-demand/merge-conflict-resolver"
+  ]
 }


### PR DESCRIPTION
Fixes agent discovery for new features.

Adds to plugin.json:
- prd-parser agent
- merge-conflict-resolver agent  
- pop-complexity-analyzer skill
- pop-changelog-automation skill

Required for Claude Code to load these features after hot-reload.