### PR TITLE
fix: remove invalid plugin manifest fields and tools

### DIFF
--- a/packages/popkit-core/.claude-plugin/plugin.json
+++ b/packages/popkit-core/.claude-plugin/plugin.json
@@ -38,8 +38,5 @@
   ],
   "agents": [
     "./agents/orchestrator/AGENT.md"
-  ],
-  "status_line": {
-    "script": "power-mode/statusline.py"
-  }
+  ]
 }

--- a/packages/popkit-core/agents/tier-2-on-demand/dead-code-eliminator/AGENT.md
+++ b/packages/popkit-core/agents/tier-2-on-demand/dead-code-eliminator/AGENT.md
@@ -8,7 +8,6 @@ tools:
   - MultiEdit
   - Grep
   - Glob
-  - LS
   # Dead code detection
   - Bash(npx ts-unused-exports*)
   - Bash(npx unimported*)

--- a/packages/popkit-dev/agents/feature-workflow/code-explorer/AGENT.md
+++ b/packages/popkit-dev/agents/feature-workflow/code-explorer/AGENT.md
@@ -5,7 +5,6 @@ tools:
   - Read
   - Grep
   - Glob
-  - LS
 output_style: agent-handoff
 model: inherit
 version: 1.0.0

--- a/packages/popkit-research/agents/tier-2-on-demand/researcher/AGENT.md
+++ b/packages/popkit-research/agents/tier-2-on-demand/researcher/AGENT.md
@@ -8,7 +8,6 @@ tools:
   - WebFetch
   - WebSearch
   - Task
-  - LS
 output_style: analysis-report
 model: inherit
 version: 1.0.0


### PR DESCRIPTION
## Problem

Plugin installation was failing with validation errors:
- `Unrecognized key: "status_line"` in popkit-core
- `agents: Invalid input` from invalid `LS` tool in 3 agents

## Changes

1. **Removed invalid `status_line` key** from popkit-core plugin.json
   - This field is not recognized by Claude Code 2.1.2
   - Was preventing plugin installation

2. **Removed invalid `LS` tool** from 3 agent files:
   - `code-explorer` (popkit-dev)
   - `dead-code-eliminator` (popkit-core)  
   - `researcher` (popkit-research)
   - `LS` is not a valid Claude Code tool

## Testing

All plugin tests pass:
```
python packages/popkit-core/run_all_tests.py
# Result: 31/31 tests passed (100%)
```

## Result

- All plugins now install successfully from local packages
- Ready for marketplace distribution

---

Fixes #TBD