### PR TITLE
fix: align plugin.json files with official Claude Code format

### DIFF
--- a/packages/popkit-core/.claude-plugin/marketplace.json
+++ b/packages/popkit-core/.claude-plugin/marketplace.json
@@ -13,7 +13,8 @@
   "homepage": "https://github.com/jrc1883/popkit-claude",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jrc1883/popkit-claude"
+    "url": "https://github.com/jrc1883/popkit-claude",
+    "directory": "packages/popkit-core"
   },
   "bugs": {
     "url": "https://github.com/jrc1883/popkit-claude/issues"

--- a/packages/popkit-core/.claude-plugin/plugin.json
+++ b/packages/popkit-core/.claude-plugin/plugin.json
@@ -7,44 +7,9 @@
     "email": "joseph@thehouseofdeals.com"
   },
   "license": "MIT",
-  "repository": "https://github.com/jrc1883/popkit-claude",
-  "commands": [
-    "./commands/plugin.md",
-    "./commands/stats.md",
-    "./commands/privacy.md",
-    "./commands/account.md",
-    "./commands/dashboard.md",
-    "./commands/bug.md",
-    "./commands/power.md",
-    "./commands/project.md",
-    "./commands/record.md"
-  ],
-  "skills": [
-    "./skills/pop-analyze-project",
-    "./skills/pop-auto-docs",
-    "./skills/pop-bug-reporter",
-    "./skills/pop-cloud-signup",
-    "./skills/pop-dashboard",
-    "./skills/pop-doc-sync",
-    "./skills/pop-embed-content",
-    "./skills/pop-embed-project",
-    "./skills/pop-mcp-generator",
-    "./skills/pop-plugin-test",
-    "./skills/pop-power-mode",
-    "./skills/pop-project-init",
-    "./skills/pop-project-templates",
-    "./skills/pop-skill-generator",
-    "./skills/pop-validation-engine"
-  ],
-  "agents": [
-    "./agents/tier-1-always-active/accessibility-guardian",
-    "./agents/tier-1-always-active/api-designer",
-    "./agents/tier-1-always-active/documentation-maintainer",
-    "./agents/tier-1-always-active/migration-specialist",
-    "./agents/tier-2-on-demand/bundle-analyzer",
-    "./agents/tier-2-on-demand/dead-code-eliminator",
-    "./agents/tier-2-on-demand/feature-prioritizer",
-    "./agents/tier-2-on-demand/meta-agent",
-    "./agents/tier-2-on-demand/power-coordinator"
-  ]
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jrc1883/popkit-claude",
+    "directory": "packages/popkit-core"
+  }
 }

--- a/packages/popkit-dev/.claude-plugin/plugin.json
+++ b/packages/popkit-dev/.claude-plugin/plugin.json
@@ -7,40 +7,9 @@
     "email": "joseph@thehouseofdeals.com"
   },
   "license": "MIT",
-  "repository": "https://github.com/jrc1883/popkit-claude",
-  "commands": [
-    "./commands/dev.md",
-    "./commands/git.md",
-    "./commands/issue.md",
-    "./commands/milestone.md",
-    "./commands/worktree.md",
-    "./commands/routine.md",
-    "./commands/next.md"
-  ],
-  "skills": [
-    "./skills/pop-brainstorming",
-    "./skills/pop-writing-plans",
-    "./skills/pop-executing-plans",
-    "./skills/pop-next-action",
-    "./skills/pop-session-capture",
-    "./skills/pop-session-resume",
-    "./skills/pop-context-restore",
-    "./skills/pop-routine-optimized",
-    "./skills/pop-routine-measure",
-    "./skills/pop-finish-branch",
-    "./skills/pop-worktrees",
-    "./skills/pop-morning",
-    "./skills/pop-nightly",
-    "./skills/pop-complexity-analyzer",
-    "./skills/pop-changelog-automation"
-  ],
-  "agents": [
-    "./agents/feature-workflow/code-architect",
-    "./agents/feature-workflow/code-explorer",
-    "./agents/tier-1-always-active/code-reviewer",
-    "./agents/tier-1-always-active/refactoring-expert",
-    "./agents/tier-2-on-demand/rapid-prototyper",
-    "./agents/tier-2-on-demand/prd-parser",
-    "./agents/tier-2-on-demand/merge-conflict-resolver"
-  ]
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jrc1883/popkit-claude",
+    "directory": "packages/popkit-dev"
+  }
 }

--- a/packages/popkit-ops/.claude-plugin/plugin.json
+++ b/packages/popkit-ops/.claude-plugin/plugin.json
@@ -7,29 +7,9 @@
     "email": "joseph@thehouseofdeals.com"
   },
   "license": "MIT",
-  "repository": "https://github.com/jrc1883/popkit-claude",
-  "commands": [
-    "./commands/assess.md",
-    "./commands/audit.md",
-    "./commands/debug.md",
-    "./commands/security.md",
-    "./commands/deploy.md"
-  ],
-  "skills": [
-    "./skills/pop-assessment-anthropic",
-    "./skills/pop-assessment-security",
-    "./skills/pop-assessment-performance",
-    "./skills/pop-assessment-ux",
-    "./skills/pop-assessment-architecture",
-    "./skills/pop-systematic-debugging",
-    "./skills/pop-code-review"
-  ],
-  "agents": [
-    "./agents/tier-1-always-active/bug-whisperer",
-    "./agents/tier-1-always-active/performance-optimizer",
-    "./agents/tier-1-always-active/security-auditor",
-    "./agents/tier-1-always-active/test-writer-fixer",
-    "./agents/tier-2-on-demand/deployment-validator",
-    "./agents/tier-2-on-demand/rollback-specialist"
-  ]
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jrc1883/popkit-claude",
+    "directory": "packages/popkit-ops"
+  }
 }

--- a/packages/popkit-research/.claude-plugin/plugin.json
+++ b/packages/popkit-research/.claude-plugin/plugin.json
@@ -7,17 +7,9 @@
     "email": "joseph@thehouseofdeals.com"
   },
   "license": "MIT",
-  "repository": "https://github.com/jrc1883/popkit-claude",
-  "commands": [
-    "./commands/research.md",
-    "./commands/knowledge.md"
-  ],
-  "skills": [
-    "./skills/pop-research-capture",
-    "./skills/pop-research-merge",
-    "./skills/pop-knowledge-lookup"
-  ],
-  "agents": [
-    "./agents/tier-2-on-demand/researcher"
-  ]
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jrc1883/popkit-claude",
+    "directory": "packages/popkit-research"
+  }
 }


### PR DESCRIPTION
## Summary
- Remove auto-discovered fields (commands, skills, agents) from all plugin.json files
- Add `repository.directory` field for monorepo support in plugin.json
- Add `directory` field to marketplace.json for popkit-core
- Follows official Anthropic plugin structure from claude-plugins-official

## Changes
All four plugin.json files now match the official format:
- `packages/popkit-core/.claude-plugin/plugin.json`
- `packages/popkit-dev/.claude-plugin/plugin.json`
- `packages/popkit-ops/.claude-plugin/plugin.json`
- `packages/popkit-research/.claude-plugin/plugin.json`

Plugin components (commands, skills, agents) are now auto-discovered from their respective directories, matching the official Claude Code plugin format used by Anthropic.

## Test Plan
- [ ] Verify plugin.json files match official Anthropic format
- [ ] Test marketplace installation: `/plugin marketplace add jrc1883/popkit-claude`
- [ ] Test individual plugin installation: `/plugin install popkit-core@popkit-claude`
- [ ] Verify agents, commands, and skills are auto-discovered correctly

## References
- [Plugins reference - Claude Code Docs](https://code.claude.com/docs/en/plugins-reference)
- [claude-plugins-official](https://github.com/anthropics/claude-plugins-official)

🤖 Generated with [Claude Code](https://claude.com/claude-code)