### PR TITLE
fix: use string format for repository field in plugin.json

### DIFF
--- a/packages/popkit-core/.claude-plugin/plugin.json
+++ b/packages/popkit-core/.claude-plugin/plugin.json
@@ -7,9 +7,5 @@
     "email": "joseph@thehouseofdeals.com"
   },
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jrc1883/popkit-claude",
-    "directory": "packages/popkit-core"
-  }
+  "repository": "https://github.com/jrc1883/popkit-claude"
 }

--- a/packages/popkit-dev/.claude-plugin/plugin.json
+++ b/packages/popkit-dev/.claude-plugin/plugin.json
@@ -7,9 +7,5 @@
     "email": "joseph@thehouseofdeals.com"
   },
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jrc1883/popkit-claude",
-    "directory": "packages/popkit-dev"
-  }
+  "repository": "https://github.com/jrc1883/popkit-claude"
 }

--- a/packages/popkit-ops/.claude-plugin/plugin.json
+++ b/packages/popkit-ops/.claude-plugin/plugin.json
@@ -7,9 +7,5 @@
     "email": "joseph@thehouseofdeals.com"
   },
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jrc1883/popkit-claude",
-    "directory": "packages/popkit-ops"
-  }
+  "repository": "https://github.com/jrc1883/popkit-claude"
 }

--- a/packages/popkit-research/.claude-plugin/plugin.json
+++ b/packages/popkit-research/.claude-plugin/plugin.json
@@ -7,9 +7,5 @@
     "email": "joseph@thehouseofdeals.com"
   },
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jrc1883/popkit-claude",
-    "directory": "packages/popkit-research"
-  }
+  "repository": "https://github.com/jrc1883/popkit-claude"
 }


### PR DESCRIPTION
## Summary
- Fixed plugin.json `repository` field to use string format instead of npm-style object
- Aligns with official Claude Code plugin schema requirements
- Resolves marketplace installation validation error

## Changes
Updated all 4 plugin manifests:
- `packages/popkit-core/.claude-plugin/plugin.json`
- `packages/popkit-dev/.claude-plugin/plugin.json`
- `packages/popkit-ops/.claude-plugin/plugin.json`
- `packages/popkit-research/.claude-plugin/plugin.json`

**Before:**
```json
"repository": {
  "type": "git",
  "url": "https://github.com/jrc1883/popkit-claude",
  "directory": "packages/popkit-core"
}
```

**After:**
```json
"repository": "https://github.com/jrc1883/popkit-claude"
```

## Validation
- ✅ All tests pass (31/31 = 100.0%)
- ✅ Matches official Claude Code plugin format (agent-sdk-dev, context7, playwright)
- ✅ Plugin validation tests confirm schema compliance

## Test plan
- [x] Run `python run_all_tests.py` - all tests pass
- [ ] Test marketplace installation after merge
- [ ] Verify plugins load correctly in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)