### PR TITLE
fix(ci): Correct parameter names in greetings workflow

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -28,8 +28,8 @@ jobs:
         if: github.event_name == 'issues'
         uses: actions/first-interaction@v3
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          issue_message: |
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
             👋 Welcome to PopKit, @${{ github.actor }}! Thanks for opening your first issue.
 
             **What happens next:**
@@ -48,8 +48,8 @@ jobs:
         if: github.event_name == 'pull_request_target'
         uses: actions/first-interaction@v3
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          pr_message: |
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-message: |
             👋 Welcome to PopKit, @${{ github.actor }}! Thanks for opening your first pull request.
 
             **What happens next:**


### PR DESCRIPTION
## Summary

Fixes the failing "Greet First-Time Contributors" GitHub Actions workflow.

## Problem

The workflow was failing with error:
\
This happened on **every PR** because the action wasn't receiving its required inputs.

## Root Cause

The \ action expects **hyphenated** parameter names:
- \ (not \)
- \ (not \)
- \ (not \)

## Changes

\
## Testing

This fix will take effect immediately on the next PR. The greeting workflow should now:
- ✅ Welcome first-time issue authors
- ✅ Welcome first-time PR contributors
- ✅ Provide helpful resources and next steps

## Related

This bug has been affecting all PRs since the workflow was added. Should resolve immediately.

🤖 Generated with Claude Code