### PR TITLE
fix: Correct greetings workflow to use underscored parameters (VERIFIED)

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -28,8 +28,8 @@ jobs:
         if: github.event_name == 'issues'
         uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             👋 Welcome to PopKit, @${{ github.actor }}! Thanks for opening your first issue.
 
             **What happens next:**
@@ -48,8 +48,8 @@ jobs:
         if: github.event_name == 'pull_request_target'
         uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_message: |
             👋 Welcome to PopKit, @${{ github.actor }}! Thanks for opening your first pull request.
 
             **What happens next:**

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,7 +1,7 @@
 # Workflow Validation
 #
 # Validates GitHub Actions workflows to prevent configuration errors:
-# - Checks for underscore parameters (should be hyphens)
+# - Checks for hyphenated parameters (should be underscores)
 # - Validates workflow syntax with actionlint
 # - Prevents merging broken workflows
 #
@@ -36,29 +36,29 @@ jobs:
         run: |
           echo "Checking .github/workflows/greetings.yml for correct parameter naming..."
 
-          # Check for incorrect underscore parameters (ignore comments)
-          if grep -v '^\s*#' .github/workflows/greetings.yml | grep -E 'repo_token:|issue_message:|pr_message:' 2>/dev/null; then
-            echo "❌ ERROR: greetings.yml uses underscores instead of hyphens"
+          # Check for incorrect hyphenated parameters (ignore comments)
+          if grep -v '^\s*#' .github/workflows/greetings.yml | grep -E 'repo-token:|issue-message:|pr-message:' 2>/dev/null; then
+            echo "❌ ERROR: greetings.yml uses hyphens instead of underscores"
             echo ""
-            echo "Found incorrect parameters (underscores):"
-            grep -v '^\s*#' .github/workflows/greetings.yml | grep -n -E 'repo_token:|issue_message:|pr_message:' || true
+            echo "Found incorrect parameters (hyphens):"
+            grep -v '^\s*#' .github/workflows/greetings.yml | grep -n -E 'repo-token:|issue-message:|pr-message:' || true
             echo ""
             echo "Correct format:"
-            echo "  repo-token: \${{ secrets.GITHUB_TOKEN }}"
-            echo "  issue-message: |"
-            echo "  pr-message: |"
+            echo "  repo_token: \${{ secrets.GITHUB_TOKEN }}"
+            echo "  issue_message: |"
+            echo "  pr_message: |"
             echo ""
             echo "See CLAUDE.md 'GitHub Actions Standards' section for details"
             exit 1
           fi
 
-          # Verify correct hyphenated parameters exist
-          if ! grep -q 'repo-token:' .github/workflows/greetings.yml; then
-            echo "❌ ERROR: greetings.yml missing repo-token parameter"
+          # Verify correct underscored parameters exist
+          if ! grep -q 'repo_token:' .github/workflows/greetings.yml; then
+            echo "❌ ERROR: greetings.yml missing repo_token parameter"
             exit 1
           fi
 
-          echo "✅ greetings.yml uses correct hyphenated parameters"
+          echo "✅ greetings.yml uses correct underscored parameters"
 
       - name: Check all workflows for common issues
         id: check-all
@@ -72,8 +72,8 @@ jobs:
             if [ -f "$file" ]; then
               # Check actions/first-interaction specifically (ignore comments)
               if grep -q 'uses: actions/first-interaction' "$file"; then
-                if grep -v '^\s*#' "$file" | grep -E 'repo_token:|issue_message:|pr_message:' >/dev/null 2>&1; then
-                  echo "⚠️  $file: uses actions/first-interaction with underscored parameters"
+                if grep -v '^\s*#' "$file" | grep -E 'repo-token:|issue-message:|pr-message:' >/dev/null 2>&1; then
+                  echo "⚠️  $file: uses actions/first-interaction with hyphenated parameters"
                   files_with_issues+=("$file")
                 fi
               fi
@@ -85,7 +85,7 @@ jobs:
             echo "❌ Found workflows with parameter naming issues:"
             printf '%s\n' "${files_with_issues[@]}"
             echo ""
-            echo "GitHub Actions require hyphenated parameter names (kebab-case)."
+            echo "GitHub Actions require underscored parameter names (snake_case) for actions/first-interaction."
             echo "See CLAUDE.md 'GitHub Actions Standards' section for details."
             exit 1
           fi
@@ -103,6 +103,6 @@ jobs:
           echo "✅ All workflow validations passed!"
           echo ""
           echo "Validated:"
-          echo "  - Parameter naming (hyphens not underscores)"
+          echo "  - Parameter naming (underscores not hyphens)"
           echo "  - Workflow syntax (actionlint)"
           echo "  - Common configuration issues"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -652,31 +652,33 @@ Before committing git-related code:
 
 PopKit enforces specific standards for GitHub Actions workflows to prevent configuration errors.
 
-### Core Principle: Hyphenated Parameters
+### Core Principle: Underscored Parameters for actions/first-interaction
 
-**GitHub Actions workflows MUST use hyphenated parameter names** (kebab-case), not underscores.
+**The `actions/first-interaction@v3` action MUST use underscored parameter names** (snake_case), not hyphens.
+
+**IMPORTANT**: This is action-specific. While many GitHub Actions use hyphenated parameters (kebab-case), `actions/first-interaction` explicitly requires underscores.
 
 ### Parameter Naming Convention
 
-When using actions in workflows, the `with:` section requires hyphens:
+When using `actions/first-interaction` in workflows, the `with:` section requires underscores:
 
 ```yaml
-# ✅ CORRECT - Hyphens (kebab-case)
-- uses: actions/first-interaction@v3
-  with:
-    repo-token: ${{ secrets.GITHUB_TOKEN }}
-    issue-message: |
-      Welcome message here
-    pr-message: |
-      PR welcome message here
-
-# ❌ WRONG - Underscores (snake_case)
+# ✅ CORRECT - Underscores (snake_case)
 - uses: actions/first-interaction@v3
   with:
     repo_token: ${{ secrets.GITHUB_TOKEN }}
     issue_message: |
-      This will fail!
+      Welcome message here
     pr_message: |
+      PR welcome message here
+
+# ❌ WRONG - Hyphens (kebab-case)
+- uses: actions/first-interaction@v3
+  with:
+    repo-token: ${{ secrets.GITHUB_TOKEN }}
+    issue-message: |
+      This will fail!
+    pr-message: |
       This will fail!
 ```
 
@@ -684,21 +686,31 @@ When using actions in workflows, the `with:` section requires hyphens:
 
 | Action | Parameter | Correct Format |
 |--------|-----------|----------------|
-| `actions/first-interaction@v3` | Token | `repo-token` |
-| `actions/first-interaction@v3` | Issue message | `issue-message` |
-| `actions/first-interaction@v3` | PR message | `pr-message` |
+| `actions/first-interaction@v3` | Token | `repo_token` |
+| `actions/first-interaction@v3` | Issue message | `issue_message` |
+| `actions/first-interaction@v3` | PR message | `pr_message` |
 
-### Historical Context
+### Historical Context (Lesson Learned)
 
-- **PR #154**: Fixed greetings workflow (underscores → hyphens) ✅
-- **PR #159**: Accidentally reverted (hyphens → underscores) ❌
-- **PR #161**: Re-fixed (underscores → hyphens) ✅
+- **PR #154**: Changed underscores → hyphens (broke workflow) ❌
+- **PR #159**: Reverted hyphens → underscores (fixed workflow) ✅
+- **PR #161**: Changed underscores → hyphens again (broke workflow) ❌
+  *This PR was created due to confusion about the correct format*
+- **Current PR**: Changed hyphens → underscores (correct fix) ✅
+
+**Root Cause**: The error message from `actions/first-interaction@v3` explicitly states:
+```
+Unexpected input(s) 'repo-token', 'pr-message'
+valid inputs are ['issue_message', 'pr_message', 'repo_token']
+```
+
+This action uses underscores, unlike most GitHub Actions which use hyphens.
 
 ### Validation
 
 Workflows in `.github/workflows/` are validated by:
 
-1. **CI Validation** (planned): Automated workflow linting
+1. **CI Validation** (`.github/workflows/workflow-lint.yml`): Checks for hyphenated parameters as errors
 2. **This Documentation**: Context for AI models to prevent errors
 3. **Manual Review**: PRs touching workflows require extra scrutiny
 
@@ -706,12 +718,12 @@ Workflows in `.github/workflows/` are validated by:
 
 Before modifying GitHub Actions workflows:
 
-- [ ] Does it use hyphenated parameter names (kebab-case)?
+- [ ] Does it use underscored parameter names (snake_case) for `actions/first-interaction`?
 - [ ] Have you tested the workflow in a feature branch?
 - [ ] Does it reference the correct action version?
 - [ ] Are all required parameters provided?
 
-**If any answer is "no", the workflow may fail in CI.**
+**If any answer is "no", the workflow will fail in CI.**
 
 ---
 


### PR DESCRIPTION
## Summary

**VERIFIED AGAINST OFFICIAL SOURCE CODE:**
https://github.com/actions/first-interaction/blob/main/action.yml

The `actions/first-interaction@v3` action explicitly defines parameters with **underscores**, NOT hyphens:
- ✅ `repo_token` (not `repo-token`)
- ✅ `issue_message` (not `issue-message`)
- ✅ `pr_message` (not `pr-message`)

## Changes

1. **`.github/workflows/greetings.yml`**: Changed parameters back to underscores
2. **`.github/workflows/workflow-lint.yml`**: Updated validation logic to check for hyphens as errors
3. **`CLAUDE.md`**: Corrected documentation with proper historical context and source verification

## Problem This Fixes

PR #165 failed with this error:
```
Unexpected input(s) 'repo-token', 'pr-message'
valid inputs are ['issue_message', 'pr_message', 'repo_token']
```

## Historical Context (Lesson Learned)

- **PR #154**: Changed to hyphens → broke workflow ❌
- **PR #159**: Reverted to underscores → fixed workflow ✅
- **PR #161**: Changed to hyphens again → broke workflow again ❌
- **This PR**: Changed to underscores → FINAL FIX (verified against source) ✅

## Verification

The official `action.yml` file from `actions/first-interaction` repository explicitly defines:
```yaml
inputs:
  repo_token:
    description: 'Token for the repository'
  issue_message:
    description: 'Comment to post on first issue'
  pr_message:
    description: 'Comment to post on first PR'
```

This matches the error message shown in PR #165 CI failure.

## Testing

- ✅ Verified parameter names against official source code
- ✅ Updated validation to prevent future errors
- ✅ Updated documentation with source references
- ✅ Workflow validation CI will now catch hyphens as errors

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)