### PR TITLE
fix(ci): clean node_modules before wrangler deploy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -109,6 +109,9 @@ jobs:
           name: docs-build
           path: packages/docs/dist
 
+      - name: Clean node_modules to avoid workspace symlink conflicts
+        run: rm -rf node_modules
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
@@ -157,6 +160,9 @@ jobs:
         with:
           name: docs-build
           path: packages/docs/dist
+
+      - name: Clean node_modules to avoid workspace symlink conflicts
+        run: rm -rf node_modules
 
       - name: Deploy preview to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
## Problem

The `Deploy Preview` job in `deploy-docs.yml` fails with `EISDIR` errors when `cloudflare/wrangler-action@v3` tries to install wrangler:

```
npm error code EISDIR
npm error syscall symlink
npm error EISDIR: illegal operation on a directory, symlink '.../packages/docs' -> '.../node_modules/@popkit/docs'
```

## Root Cause

The self-hosted runner preserves workspace state between jobs. The `build` job runs `npm ci` which creates workspace symlinks in `node_modules` (e.g. `node_modules/@popkit/docs` -> `packages/docs`). When the `deploy`/`preview` jobs then run `cloudflare/wrangler-action`, it tries to `npm install wrangler` into the same `node_modules` directory, hitting `EISDIR` errors on the existing workspace symlinks.

## Fix

Add `rm -rf node_modules` before the wrangler action in both the `deploy` and `preview` jobs. These jobs only need the pre-built artifact + wrangler CLI, not the workspace dependencies.

## Test plan
- [ ] Re-run the failed Deploy Preview check on PR #224 after merging this fix

Generated with [Claude Code](https://claude.com/claude-code)