### PR TITLE
feat: add memory frontmatter to all 23 agents (CC 2.1.33)

### DIFF
--- a/packages/popkit-core/agents/tier-1-always-active/accessibility-guardian/AGENT.md
+++ b/packages/popkit-core/agents/tier-1-always-active/accessibility-guardian/AGENT.md
@@ -9,6 +9,7 @@ tools:
 output_style: accessibility-audit
 model: inherit
 version: 1.0.0
+memory: user
 ---
 
 # Accessibility Guardian Agent

--- a/packages/popkit-core/agents/tier-1-always-active/api-designer/AGENT.md
+++ b/packages/popkit-core/agents/tier-1-always-active/api-designer/AGENT.md
@@ -11,6 +11,7 @@ tools:
 output_style: api-design-report
 model: inherit
 version: 1.0.0
+memory: user
 ---
 
 # API Designer Agent

--- a/packages/popkit-core/agents/tier-1-always-active/documentation-maintainer/AGENT.md
+++ b/packages/popkit-core/agents/tier-1-always-active/documentation-maintainer/AGENT.md
@@ -12,6 +12,7 @@ tools:
 output_style: documentation-report
 model: inherit
 version: 1.0.0
+memory: project
 ---
 
 # Documentation Maintainer Agent

--- a/packages/popkit-core/agents/tier-1-always-active/migration-specialist/AGENT.md
+++ b/packages/popkit-core/agents/tier-1-always-active/migration-specialist/AGENT.md
@@ -28,6 +28,7 @@ tools:
 output_style: migration-report
 model: inherit
 version: 1.0.0
+memory: project
 ---
 
 # Migration Specialist Agent

--- a/packages/popkit-core/agents/tier-2-on-demand/bundle-analyzer/AGENT.md
+++ b/packages/popkit-core/agents/tier-2-on-demand/bundle-analyzer/AGENT.md
@@ -24,6 +24,7 @@ tools:
 output_style: bundle-report
 model: inherit
 version: 1.0.0
+memory: project
 ---
 
 # Bundle Analyzer Agent

--- a/packages/popkit-core/agents/tier-2-on-demand/dead-code-eliminator/AGENT.md
+++ b/packages/popkit-core/agents/tier-2-on-demand/dead-code-eliminator/AGENT.md
@@ -23,6 +23,7 @@ tools:
 output_style: code-optimization-report
 model: inherit
 version: 1.0.0
+memory: project
 ---
 
 # Dead Code Eliminator Agent

--- a/packages/popkit-core/agents/tier-2-on-demand/feature-prioritizer/AGENT.md
+++ b/packages/popkit-core/agents/tier-2-on-demand/feature-prioritizer/AGENT.md
@@ -10,6 +10,7 @@ tools:
 output_style: prioritization-report
 model: inherit
 version: 1.0.0
+memory: user
 ---
 
 # Feature Prioritizer Agent

--- a/packages/popkit-core/agents/tier-2-on-demand/meta-agent/AGENT.md
+++ b/packages/popkit-core/agents/tier-2-on-demand/meta-agent/AGENT.md
@@ -10,6 +10,7 @@ tools:
 output_style: agent-specification
 model: inherit
 version: 1.0.0
+memory: user
 ---
 
 # Meta Agent - Agent Creator

--- a/packages/popkit-core/agents/tier-2-on-demand/power-coordinator/AGENT.md
+++ b/packages/popkit-core/agents/tier-2-on-demand/power-coordinator/AGENT.md
@@ -20,6 +20,7 @@ tools:
 output_style: power-mode-checkin
 model: inherit
 version: 1.0.0
+memory: local
 ---
 
 # Power Coordinator Agent

--- a/packages/popkit-dev/agents/feature-workflow/code-architect/AGENT.md
+++ b/packages/popkit-dev/agents/feature-workflow/code-architect/AGENT.md
@@ -9,6 +9,7 @@ tools:
 output_style: agent-handoff
 model: inherit
 version: 1.0.0
+memory: project
 ---
 
 # Code Architect Agent

--- a/packages/popkit-dev/agents/feature-workflow/code-explorer/AGENT.md
+++ b/packages/popkit-dev/agents/feature-workflow/code-explorer/AGENT.md
@@ -8,6 +8,7 @@ tools:
 output_style: agent-handoff
 model: inherit
 version: 1.0.0
+memory: project
 ---
 
 # Code Explorer Agent

--- a/packages/popkit-dev/agents/tier-1-always-active/code-reviewer/AGENT.md
+++ b/packages/popkit-dev/agents/tier-1-always-active/code-reviewer/AGENT.md
@@ -9,6 +9,7 @@ tools:
 output_style: code-review-report
 model: inherit
 version: 1.0.0
+memory: project
 ---
 
 # Code Reviewer Agent

--- a/packages/popkit-dev/agents/tier-1-always-active/refactoring-expert/AGENT.md
+++ b/packages/popkit-dev/agents/tier-1-always-active/refactoring-expert/AGENT.md
@@ -21,6 +21,7 @@ tools:
 output_style: refactoring-report
 model: inherit
 version: 1.0.0
+memory: project
 ---
 
 # Refactoring Expert Agent

--- a/packages/popkit-dev/agents/tier-2-on-demand/merge-conflict-resolver/AGENT.md
+++ b/packages/popkit-dev/agents/tier-2-on-demand/merge-conflict-resolver/AGENT.md
@@ -20,6 +20,7 @@ tools:
 output_style: conflict-resolution-report
 model: inherit
 version: 1.0.0
+memory: local
 triggers:
   - "merge conflict"
   - "resolve conflicts"

--- a/packages/popkit-dev/agents/tier-2-on-demand/prd-parser/AGENT.md
+++ b/packages/popkit-dev/agents/tier-2-on-demand/prd-parser/AGENT.md
@@ -13,6 +13,7 @@ tools:
 output_style: structured-planning
 model: inherit
 version: 1.0.0
+memory: user
 triggers:
   - "parse this PRD"
   - "analyze requirements document"

--- a/packages/popkit-dev/agents/tier-2-on-demand/rapid-prototyper/AGENT.md
+++ b/packages/popkit-dev/agents/tier-2-on-demand/rapid-prototyper/AGENT.md
@@ -25,6 +25,7 @@ tools:
 output_style: prototype-report
 model: inherit
 version: 1.0.0
+memory: project
 ---
 
 # Rapid Prototyper Agent

--- a/packages/popkit-ops/agents/tier-1-always-active/bug-whisperer/AGENT.md
+++ b/packages/popkit-ops/agents/tier-1-always-active/bug-whisperer/AGENT.md
@@ -27,6 +27,7 @@ tools:
 output_style: debugging-report
 model: inherit
 version: 1.0.0
+memory: project
 ---
 
 # Bug Whisperer Agent

--- a/packages/popkit-ops/agents/tier-1-always-active/performance-optimizer/AGENT.md
+++ b/packages/popkit-ops/agents/tier-1-always-active/performance-optimizer/AGENT.md
@@ -25,6 +25,7 @@ tools:
 output_style: performance-report
 model: inherit
 version: 1.0.0
+memory: project
 ---
 
 # Performance Optimizer Agent

--- a/packages/popkit-ops/agents/tier-1-always-active/security-auditor/AGENT.md
+++ b/packages/popkit-ops/agents/tier-1-always-active/security-auditor/AGENT.md
@@ -24,6 +24,7 @@ tools:
 output_style: security-audit-report
 model: inherit
 version: 1.0.0
+memory: project
 hooks:
   PreToolUse:
     - script: "${CLAUDE_PLUGIN_ROOT}/../../shared-py/hooks/validate-security-tool.py"

--- a/packages/popkit-ops/agents/tier-1-always-active/test-writer-fixer/AGENT.md
+++ b/packages/popkit-ops/agents/tier-1-always-active/test-writer-fixer/AGENT.md
@@ -24,6 +24,7 @@ tools:
 output_style: testing-report
 model: inherit
 version: 1.0.0
+memory: project
 hooks:
   PostToolUse:
     - script: "${CLAUDE_PLUGIN_ROOT}/../../shared-py/hooks/auto-run-tests.py"

--- a/packages/popkit-ops/agents/tier-2-on-demand/deployment-validator/AGENT.md
+++ b/packages/popkit-ops/agents/tier-2-on-demand/deployment-validator/AGENT.md
@@ -30,6 +30,7 @@ tools:
 output_style: deployment-report
 model: inherit
 version: 1.0.0
+memory: local
 ---
 
 # Deployment Validator Agent

--- a/packages/popkit-ops/agents/tier-2-on-demand/rollback-specialist/AGENT.md
+++ b/packages/popkit-ops/agents/tier-2-on-demand/rollback-specialist/AGENT.md
@@ -28,6 +28,7 @@ tools:
 output_style: rollback-report
 model: inherit
 version: 1.0.0
+memory: local
 ---
 
 # Rollback Specialist Agent

--- a/packages/popkit-research/agents/tier-2-on-demand/researcher/AGENT.md
+++ b/packages/popkit-research/agents/tier-2-on-demand/researcher/AGENT.md
@@ -11,6 +11,7 @@ tools:
 output_style: analysis-report
 model: inherit
 version: 1.0.0
+memory: user
 ---
 
 # Researcher Agent - Agent Discovery & Analysis


### PR DESCRIPTION
## Summary

- Adds `memory` frontmatter field to all 23 AGENT.md files across all 4 plugins
- Implements Claude Code 2.1.33 Agent Memory feature for persistent agent state across sessions
- Memory scopes assigned based on agent role:
  - **user** (6 agents): Cross-project knowledge (accessibility-guardian, api-designer, feature-prioritizer, meta-agent, prd-parser, researcher)
  - **project** (13 agents): Project-specific learning (documentation-maintainer, migration-specialist, bundle-analyzer, dead-code-eliminator, code-architect, code-explorer, code-reviewer, refactoring-expert, rapid-prototyper, bug-whisperer, performance-optimizer, security-auditor, test-writer-fixer)
  - **local** (4 agents): Session-scoped state (power-coordinator, merge-conflict-resolver, deployment-validator, rollback-specialist)

Closes #67

## Test plan

- [x] All 23 AGENT.md files verified with `memory` field
- [x] Plugin tests pass (94.6% - 4 pre-existing failures unrelated)
- [x] Cross-plugin validation: 11/11 passing
- [ ] Verify agents load correctly after plugin install

🤖 Generated with [Claude Code](https://claude.com/claude-code)