### PR TITLE
feat: add TeammateIdle and TaskCompleted hooks (CC 2.1.33)

### DIFF
--- a/.github/scripts/comprehensive-validation.py
+++ b/.github/scripts/comprehensive-validation.py
@@ -59,6 +59,8 @@ class PluginValidator:
         "SessionEnd",
         "PreCompact",
         "Setup",
+        "TeammateIdle",
+        "TaskCompleted",
     }
 
     VALID_LICENSES = {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -411,6 +411,55 @@ PopKit Core includes an automatic **Ruff pre-commit hook** that validates Python
 - Backgrounded hook commands with `"blocking": false` now correctly return early
 - Enables more PopKit hooks to run non-blocking without session delays
 
+### New in Claude Code 2.1.20
+
+**PR Status Footer:**
+
+- Native PR review status indicator in the prompt footer
+- PopKit can reduce redundant PR status queries in workflows
+- `--add-dir` flag and `CLAUDE_ADD_DIR` env var load CLAUDE.md from additional directories
+
+**Background Agent Permissions:**
+
+- Background agents now prompt for permissions before launch (not after)
+- `Bash(*)` is equivalent to `Bash` (validates PopKit's wildcard permission approach)
+- `TaskUpdate` gains `delete` capability for cleaner task cleanup
+
+### New in Claude Code 2.1.21
+
+**File Tool Preference:**
+
+- Model now prefers Read/Edit/Write tools over bash equivalents (cat/sed/awk)
+- Validates PopKit's agent permission model (agents don't need `Bash(cat *)`)
+- VSCode auto-activates Python venv for hook execution
+
+### New in Claude Code 2.1.27
+
+**PR Workflow Improvements:**
+
+- `--from-pr` flag links sessions to specific pull requests
+- Auto PR linking via `gh pr create` for better traceability
+- Tool denials now appear in debug logs (helps debug agent permissions)
+
+**Windows Compatibility:**
+
+- Fixed .bashrc compatibility for Windows environments
+- Important for Windows PopKit hook execution reliability
+
+### New in Claude Code 2.1.30
+
+**PDF and Research:**
+
+- `pages` parameter on Read tool for large PDFs (e.g., `pages: "1-5"`)
+- PDFs >10 pages return `@` reference instead of inline content
+- PopKit research workflows should use `pages` parameter for large documents
+
+**Task Tool Metrics:**
+
+- Task results now include token count, tool uses, and duration
+- PopKit's `chain-metrics.py` can consume native metrics instead of computing manually
+- New `/debug` command for session troubleshooting
+
 ### New in Claude Code 2.1.32
 
 **Claude Opus 4.6:**
@@ -769,12 +818,17 @@ PopKit requires specific Claude Code versions for full functionality:
 | **Customizable Keybindings**    | 2.1.18          | `/keybindings` for personalized shortcuts      |
 | **Argument Bracket Syntax**     | 2.1.19          | `$ARGUMENTS[0]` replaces `$ARGUMENTS.0`        |
 | **Auto-Approved Simple Skills** | 2.1.19          | Skills without hooks/permissions skip approval  |
+| **Background Hook Fix**         | 2.1.19          | Non-blocking hooks return early correctly       |
 | **PR Status Footer**            | 2.1.20          | Native PR review status in prompt footer       |
 | **Additional Dir CLAUDE.md**    | 2.1.20          | `--add-dir` loads CLAUDE.md from extra dirs    |
+| **Bash(*) = Bash Equivalence**  | 2.1.20          | Validates wildcard permission design            |
 | **File Tool Preference**        | 2.1.21          | Model prefers Read/Edit/Write over bash equiv  |
+| **Async Hook Cancellation**     | 2.1.23          | Pending hooks cancelled on session end         |
 | **PR Session Linking**          | 2.1.27          | `--from-pr` flag and auto-linking via `gh pr`  |
+| **Windows Bash Fix**            | 2.1.27          | .bashrc compatibility for Windows hooks        |
 | **PDF Page Ranges**             | 2.1.30          | `pages` parameter on Read tool for PDFs        |
 | **Task Tool Metrics**           | 2.1.30          | Token count, tool uses, duration in results    |
+| **Debug Command**               | 2.1.30          | `/debug` for session troubleshooting           |
 | **Claude Opus 4.6**             | 2.1.32          | New frontier model available                   |
 | **Agent Teams (Preview)**       | 2.1.32          | Native multi-agent collaboration               |
 | **Agent Memory**                | 2.1.32          | Automatic memory recording and recall          |
@@ -800,7 +854,8 @@ PopKit requires specific Claude Code versions for full functionality:
 
 ### Recent Updates
 
-- **2026-02-06**: Claude Code 2.1.33 compatibility audit, version table updated (27 versions documented)
+- **2026-02-06**: TeammateIdle + TaskCompleted hooks, CC 2.1.7-2.1.33 full changelog audit, version table expanded (42 entries)
+- **2026-02-06**: CC 2.1.33 integration, agent memory, interactive init, routing accuracy (v1.0.0-beta.8)
 - **2026-02-05**: Issue triage and cleanup (17 issues closed), commenting standards, design integration strategy
 - **2026-01-31**: GitHub cache, priority scheduling, agent expertise system (v1.0.0-beta.7)
 - **2026-01-13**: CI/CD pipeline complete, all tests passing (v1.0.0-beta.5)

--- a/packages/popkit-core/hooks/hooks.json
+++ b/packages/popkit-core/hooks/hooks.json
@@ -172,6 +172,30 @@
           }
         ]
       }
+    ],
+    "TeammateIdle": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/teammate-idle.py\"",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/task-completed.py\"",
+            "timeout": 5000
+          }
+        ]
+      }
     ]
   }
 }

--- a/packages/popkit-core/hooks/task-completed.py
+++ b/packages/popkit-core/hooks/task-completed.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+TaskCompleted Hook (Claude Code 2.1.33+)
+Fires when a task (subagent or todo item) completes.
+
+Responsibilities:
+1. Log task completion metrics (duration, tools, tokens)
+2. Update STATUS.json with task outcome
+3. Track cumulative session metrics
+"""
+
+import sys
+import json
+from pathlib import Path
+from datetime import datetime
+
+
+def log_task_completion(data):
+    """Log task completion event."""
+    logs_dir = Path(".claude", "popkit", "logs")
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    log_file = logs_dir / "task-completions.json"
+
+    entry = {
+        "event": "task_completed",
+        "task_id": data.get("task_id", data.get("id", "unknown")),
+        "task_description": data.get("description", ""),
+        "status": data.get("status", "completed"),
+        "duration_ms": data.get("duration_ms", 0),
+        "tools_used": data.get("tools_used", 0),
+        "tokens_used": data.get("tokens_used", 0),
+        "agent": data.get("agent", data.get("agent_type", "")),
+        "timestamp": datetime.now().isoformat(),
+    }
+
+    # Append to log file
+    events = []
+    if log_file.exists():
+        try:
+            with open(log_file, "r", encoding="utf-8") as f:
+                events = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            events = []
+
+    events.append(entry)
+
+    # Keep last 200 events
+    if len(events) > 200:
+        events = events[-200:]
+
+    try:
+        with open(log_file, "w", encoding="utf-8") as f:
+            json.dump(events, f, indent=2)
+    except OSError as e:
+        print(f"  Warning: failed to write task log: {e}", file=sys.stderr)
+
+    return entry
+
+
+def update_session_metrics(data):
+    """Update cumulative session metrics in STATUS.json."""
+    status_file = Path(".claude", "STATUS.json")
+
+    status = {}
+    if status_file.exists():
+        try:
+            with open(status_file, "r", encoding="utf-8") as f:
+                status = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            status = {}
+
+    # Update session metrics
+    metrics = status.get(
+        "session_metrics",
+        {
+            "tasks_completed": 0,
+            "total_duration_ms": 0,
+            "total_tokens": 0,
+            "total_tools": 0,
+        },
+    )
+
+    metrics["tasks_completed"] = metrics.get("tasks_completed", 0) + 1
+    metrics["total_duration_ms"] = metrics.get("total_duration_ms", 0) + data.get(
+        "duration_ms", 0
+    )
+    metrics["total_tokens"] = metrics.get("total_tokens", 0) + data.get(
+        "tokens_used", 0
+    )
+    metrics["total_tools"] = metrics.get("total_tools", 0) + data.get("tools_used", 0)
+    metrics["last_task_completed"] = datetime.now().isoformat()
+
+    status["session_metrics"] = metrics
+
+    try:
+        with open(status_file, "w", encoding="utf-8") as f:
+            json.dump(status, f, indent=2)
+    except OSError as e:
+        print(f"  Warning: failed to update STATUS.json: {e}", file=sys.stderr)
+
+
+def main():
+    """Main entry point - JSON stdin/stdout protocol."""
+    try:
+        input_data = sys.stdin.read()
+        data = json.loads(input_data) if input_data.strip() else {}
+
+        # Log the completion
+        entry = log_task_completion(data)
+
+        # Update session metrics
+        update_session_metrics(data)
+
+        task_id = entry["task_id"]
+        status = entry["status"]
+        duration = entry["duration_ms"]
+
+        if duration > 0:
+            print(
+                f"  Task {task_id} {status} ({duration}ms)",
+                file=sys.stderr,
+            )
+        else:
+            print(f"  Task {task_id} {status}", file=sys.stderr)
+
+        response = {
+            "status": "success",
+            "message": f"Task completion logged: {task_id}",
+            "timestamp": datetime.now().isoformat(),
+        }
+        print(json.dumps(response))
+
+    except json.JSONDecodeError:
+        response = {
+            "status": "success",
+            "message": "TaskCompleted hook completed (no input)",
+            "timestamp": datetime.now().isoformat(),
+        }
+        print(json.dumps(response))
+    except Exception as e:
+        response = {
+            "status": "error",
+            "error": str(e),
+            "timestamp": datetime.now().isoformat(),
+        }
+        print(json.dumps(response))
+        print(f"Error in task-completed hook: {e}", file=sys.stderr)
+        sys.exit(0)  # Never block on errors
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/popkit-core/hooks/teammate-idle.py
+++ b/packages/popkit-core/hooks/teammate-idle.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+TeammateIdle Hook (Claude Code 2.1.33+)
+Fires when an Agent Teams teammate becomes idle (waiting for work).
+
+Responsibilities:
+1. Log idle events for observability and utilization tracking
+2. Record teammate metrics (duration active, tools used)
+3. Update STATUS.json with teammate state
+"""
+
+import sys
+import json
+from pathlib import Path
+from datetime import datetime
+
+
+def log_teammate_idle(data):
+    """Log teammate idle event to observability file."""
+    logs_dir = Path(".claude", "popkit", "logs")
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    log_file = logs_dir / "teammate-events.json"
+
+    entry = {
+        "event": "teammate_idle",
+        "teammate": data.get("teammate", data.get("agent", "unknown")),
+        "reason": data.get("reason", "completed_work"),
+        "duration_ms": data.get("duration_ms", 0),
+        "tools_used": data.get("tools_used", 0),
+        "tokens_used": data.get("tokens_used", 0),
+        "timestamp": datetime.now().isoformat(),
+    }
+
+    # Append to log file
+    events = []
+    if log_file.exists():
+        try:
+            with open(log_file, "r", encoding="utf-8") as f:
+                events = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            events = []
+
+    events.append(entry)
+
+    # Keep last 100 events to prevent unbounded growth
+    if len(events) > 100:
+        events = events[-100:]
+
+    try:
+        with open(log_file, "w", encoding="utf-8") as f:
+            json.dump(events, f, indent=2)
+    except OSError as e:
+        print(f"  Warning: failed to write teammate log: {e}", file=sys.stderr)
+
+
+def update_status(data):
+    """Update STATUS.json with teammate idle state."""
+    status_file = Path(".claude", "STATUS.json")
+
+    status = {}
+    if status_file.exists():
+        try:
+            with open(status_file, "r", encoding="utf-8") as f:
+                status = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            status = {}
+
+    # Update teammates section
+    teammates = status.get("teammates", {})
+    teammate_name = data.get("teammate", data.get("agent", "unknown"))
+    teammates[teammate_name] = {
+        "state": "idle",
+        "last_active": datetime.now().isoformat(),
+        "tools_used": data.get("tools_used", 0),
+        "tokens_used": data.get("tokens_used", 0),
+    }
+    status["teammates"] = teammates
+
+    try:
+        with open(status_file, "w", encoding="utf-8") as f:
+            json.dump(status, f, indent=2)
+    except OSError as e:
+        print(f"  Warning: failed to update STATUS.json: {e}", file=sys.stderr)
+
+
+def main():
+    """Main entry point - JSON stdin/stdout protocol."""
+    try:
+        input_data = sys.stdin.read()
+        data = json.loads(input_data) if input_data.strip() else {}
+
+        # Log the idle event
+        log_teammate_idle(data)
+
+        # Update STATUS.json
+        update_status(data)
+
+        teammate = data.get("teammate", data.get("agent", "unknown"))
+        print(f"  Teammate {teammate} is now idle", file=sys.stderr)
+
+        response = {
+            "status": "success",
+            "message": f"Teammate idle event logged for {teammate}",
+            "timestamp": datetime.now().isoformat(),
+        }
+        print(json.dumps(response))
+
+    except json.JSONDecodeError:
+        response = {
+            "status": "success",
+            "message": "TeammateIdle hook completed (no input)",
+            "timestamp": datetime.now().isoformat(),
+        }
+        print(json.dumps(response))
+    except Exception as e:
+        response = {
+            "status": "error",
+            "error": str(e),
+            "timestamp": datetime.now().isoformat(),
+        }
+        print(json.dumps(response))
+        print(f"Error in teammate-idle hook: {e}", file=sys.stderr)
+        sys.exit(0)  # Never block on errors
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/popkit-core/tests/hooks/test-task-completed.json
+++ b/packages/popkit-core/tests/hooks/test-task-completed.json
@@ -1,0 +1,139 @@
+{
+  "test_id": "hook-task-completed-protocol",
+  "category": "hooks",
+  "name": "TaskCompleted Hook Metrics",
+  "description": "Verify task-completed.py logs completion metrics and updates session state",
+  "severity": "medium",
+  "hook_file": "hooks/task-completed.py",
+  "test_cases": [
+    {
+      "case_id": "basic-task-completion",
+      "name": "Basic task completion event",
+      "input": {
+        "event": "TaskCompleted",
+        "task_id": "task-001",
+        "description": "Analyze codebase structure",
+        "status": "completed",
+        "duration_ms": 30000,
+        "tools_used": 15,
+        "tokens_used": 12000,
+        "agent": "code-explorer"
+      },
+      "assertions": [
+        {
+          "type": "exit_code",
+          "expected": 0,
+          "description": "Should complete successfully"
+        },
+        {
+          "type": "json_valid",
+          "field": "stdout"
+        },
+        {
+          "type": "has_field",
+          "field": "status"
+        },
+        {
+          "type": "contains",
+          "field": "status",
+          "expected": "success"
+        },
+        {
+          "type": "duration",
+          "max_ms": 5000,
+          "description": "Should complete quickly"
+        }
+      ]
+    },
+    {
+      "case_id": "minimal-input",
+      "name": "Handles minimal input",
+      "input": {
+        "event": "TaskCompleted",
+        "task_id": "task-002"
+      },
+      "assertions": [
+        {
+          "type": "exit_code",
+          "expected": 0
+        },
+        {
+          "type": "json_valid",
+          "field": "stdout"
+        },
+        {
+          "type": "contains",
+          "field": "status",
+          "expected": "success"
+        }
+      ]
+    },
+    {
+      "case_id": "empty-input",
+      "name": "Handles empty input gracefully",
+      "input": {},
+      "assertions": [
+        {
+          "type": "exit_code",
+          "expected": 0
+        },
+        {
+          "type": "json_valid",
+          "field": "stdout"
+        },
+        {
+          "type": "contains",
+          "field": "status",
+          "expected": "success"
+        }
+      ]
+    },
+    {
+      "case_id": "invalid-json-input",
+      "name": "Handles invalid JSON input gracefully",
+      "input": "broken json!!!",
+      "assertions": [
+        {
+          "type": "exit_code",
+          "expected": 0,
+          "description": "Should not block on errors"
+        },
+        {
+          "type": "json_valid",
+          "field": "stdout"
+        }
+      ]
+    },
+    {
+      "case_id": "timestamp-present",
+      "name": "Response includes timestamp",
+      "input": {
+        "event": "TaskCompleted",
+        "task_id": "task-003",
+        "status": "completed"
+      },
+      "assertions": [
+        {
+          "type": "exit_code",
+          "expected": 0
+        },
+        {
+          "type": "json_valid",
+          "field": "stdout"
+        },
+        {
+          "type": "has_field",
+          "field": "timestamp"
+        }
+      ]
+    }
+  ],
+  "dependencies": ["hooks/task-completed.py"],
+  "notes": [
+    "TaskCompleted is a new hook event in Claude Code 2.1.33",
+    "Fires when a task (subagent or todo) completes",
+    "Logs completion metrics to .claude/popkit/logs/task-completions.json",
+    "Updates cumulative session metrics in STATUS.json",
+    "Must not block Claude operation even on errors"
+  ]
+}

--- a/packages/popkit-core/tests/hooks/test-teammate-idle.json
+++ b/packages/popkit-core/tests/hooks/test-teammate-idle.json
@@ -1,0 +1,113 @@
+{
+  "test_id": "hook-teammate-idle-protocol",
+  "category": "hooks",
+  "name": "TeammateIdle Hook Observability",
+  "description": "Verify teammate-idle.py logs idle events and updates STATUS.json",
+  "severity": "medium",
+  "hook_file": "hooks/teammate-idle.py",
+  "test_cases": [
+    {
+      "case_id": "basic-idle-event",
+      "name": "Basic teammate idle event",
+      "input": {
+        "event": "TeammateIdle",
+        "teammate": "code-reviewer",
+        "reason": "completed_work",
+        "duration_ms": 45000,
+        "tools_used": 12,
+        "tokens_used": 8500
+      },
+      "assertions": [
+        {
+          "type": "exit_code",
+          "expected": 0,
+          "description": "Should complete successfully"
+        },
+        {
+          "type": "json_valid",
+          "field": "stdout"
+        },
+        {
+          "type": "has_field",
+          "field": "status"
+        },
+        {
+          "type": "contains",
+          "field": "status",
+          "expected": "success"
+        },
+        {
+          "type": "duration",
+          "max_ms": 5000,
+          "description": "Should complete quickly"
+        }
+      ]
+    },
+    {
+      "case_id": "empty-input",
+      "name": "Handles empty input gracefully",
+      "input": {},
+      "assertions": [
+        {
+          "type": "exit_code",
+          "expected": 0
+        },
+        {
+          "type": "json_valid",
+          "field": "stdout"
+        },
+        {
+          "type": "contains",
+          "field": "status",
+          "expected": "success"
+        }
+      ]
+    },
+    {
+      "case_id": "invalid-json-input",
+      "name": "Handles invalid JSON input gracefully",
+      "input": "not valid json{",
+      "assertions": [
+        {
+          "type": "exit_code",
+          "expected": 0,
+          "description": "Should not block on errors"
+        },
+        {
+          "type": "json_valid",
+          "field": "stdout"
+        }
+      ]
+    },
+    {
+      "case_id": "timestamp-present",
+      "name": "Response includes timestamp",
+      "input": {
+        "event": "TeammateIdle",
+        "teammate": "bug-whisperer"
+      },
+      "assertions": [
+        {
+          "type": "exit_code",
+          "expected": 0
+        },
+        {
+          "type": "json_valid",
+          "field": "stdout"
+        },
+        {
+          "type": "has_field",
+          "field": "timestamp"
+        }
+      ]
+    }
+  ],
+  "dependencies": ["hooks/teammate-idle.py"],
+  "notes": [
+    "TeammateIdle is a new hook event in Claude Code 2.1.33",
+    "Fires when an Agent Teams teammate becomes idle",
+    "Logs events to .claude/popkit/logs/teammate-events.json",
+    "Updates STATUS.json with teammate state",
+    "Must not block Claude operation even on errors"
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds **TeammateIdle** hook handler — logs idle teammate events to `teammate-events.json` and updates `STATUS.json` with teammate state
- Adds **TaskCompleted** hook handler — logs task completion metrics to `task-completions.json` and tracks cumulative session metrics (tasks_completed, total_duration_ms, total_tokens, total_tools)
- Registers both new events in `hooks.json` with 5s timeouts
- Updates `comprehensive-validation.py` VALID_EVENTS to include both new event types
- Expands CLAUDE.md with CC 2.1.20–2.1.30 version sections and 5 missing version table entries (42 total)
- Adds 9 declarative test cases across both hooks

Both hooks follow the standard JSON stdin/stdout protocol, never block on errors (`sys.exit(0)`), and gracefully handle empty/invalid input.

Closes #38

## Test plan

- [x] Hook tests: 55/55 passed (100%) including 9 new test cases
- [x] CI validation: 0 errors, 0 warnings (new events recognized)
- [x] Full test suite: 72/79 (91.1%) — 7 failures are pre-existing cross-plugin issues
- [ ] Verify CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)