### PR TITLE
fix: add setup-node to deploy/preview jobs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -103,6 +103,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
       - name: Download build artifact
         uses: actions/download-artifact@v7
         with:
@@ -156,6 +161,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
 
       - name: Download build artifact
         uses: actions/download-artifact@v7


### PR DESCRIPTION
## Summary
- Add `actions/setup-node@v6` step to both `deploy` and `preview` jobs in deploy-docs.yml
- The jobs use `node` command to disable npm workspaces but didn't have Node.js set up

## Problem
Deploy Preview was failing with exit code 127 (command not found) because `node` wasn't available on the self-hosted runner.

## Changes
- Added `Setup Node.js` step before the `Disable npm workspaces` step in both jobs

## Test plan
- [ ] Verify Deploy Preview passes on this PR
- [ ] After merge, verify PRs #249 and #251 can deploy successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)