### PR TITLE
fix(dev): remove shell usage for npm install

### DIFF
--- a/packages/popkit-dev/skills/pop-worktree-manager/scripts/worktree_operations.py
+++ b/packages/popkit-dev/skills/pop-worktree-manager/scripts/worktree_operations.py
@@ -132,7 +132,9 @@ def get_project_name() -> str:
     return "project"
 
 
-def resolve_worktree_path(branch: str, config: Dict[str, Any], name: Optional[str] = None) -> Path:
+def resolve_worktree_path(
+    branch: str, config: Dict[str, Any], name: Optional[str] = None
+) -> Path:
     """
     Resolve worktree path from config template.
 
@@ -225,7 +227,9 @@ def operation_list(json_output: bool = False) -> Dict[str, Any]:
 
         # Check for uncommitted changes
         if Path(wt["path"]).exists():
-            status_output, status_ok = run_git_command(f'-C "{wt["path"]}" status --porcelain')
+            status_output, status_ok = run_git_command(
+                f'-C "{wt["path"]}" status --porcelain'
+            )
             wt["uncommittedChanges"] = bool(status_output) if status_ok else False
 
     if json_output:
@@ -394,7 +398,7 @@ def operation_update_all(install: bool = False) -> Dict[str, Any]:
         # Install dependencies if requested
         if install and Path(wt_path, "package.json").exists():
             install_result = subprocess.run(
-                "npm install", cwd=wt_path, capture_output=True, text=True, shell=True
+                ["npm", "install"], cwd=wt_path, capture_output=True, text=True
             )
             result["installSuccess"] = install_result.returncode == 0
             result["installOutput"] = install_result.stdout.strip()
@@ -499,7 +503,9 @@ def operation_analyze() -> Dict[str, Any]:
         branch = wt.get("branch", "detached")
 
         # Check if behind base branch (assume main)
-        behind_output, behind_ok = run_git_command(f'-C "{wt_path}" rev-list HEAD..main --count')
+        behind_output, behind_ok = run_git_command(
+            f'-C "{wt_path}" rev-list HEAD..main --count'
+        )
 
         if behind_ok and behind_output and int(behind_output) > 0:
             recommendations.append(
@@ -567,10 +573,14 @@ def main():
     parser.add_argument("--force", action="store_true", help="Force removal")
 
     # update-all options
-    parser.add_argument("--install", action="store_true", help="Run npm install after update")
+    parser.add_argument(
+        "--install", action="store_true", help="Run npm install after update"
+    )
 
     # prune options
-    parser.add_argument("--dry-run", action="store_true", help="Preview without executing")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Preview without executing"
+    )
 
     # init options
     parser.add_argument("--pattern", default="dev-*", help="Branch pattern for init")

--- a/packages/popkit-dev/tests/test_worktree_operations.py
+++ b/packages/popkit-dev/tests/test_worktree_operations.py
@@ -15,7 +15,9 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 # Add parent directory to path for imports
-sys.path.insert(0, str(Path(__file__).parents[1] / "skills" / "pop-worktree-manager" / "scripts"))
+sys.path.insert(
+    0, str(Path(__file__).parents[1] / "skills" / "pop-worktree-manager" / "scripts")
+)
 
 from worktree_operations import (
     DEFAULT_CONFIG,
@@ -230,7 +232,9 @@ class TestOperationCreate(unittest.TestCase):
     @patch("worktree_operations.enable_windows_longpaths")
     @patch("worktree_operations.run_git_command")
     @patch("worktree_operations.resolve_worktree_path")
-    def test_create_success(self, mock_resolve, mock_git, mock_enable, mock_load, mock_save):
+    def test_create_success(
+        self, mock_resolve, mock_git, mock_enable, mock_load, mock_save
+    ):
         """Test successful worktree creation."""
         with tempfile.TemporaryDirectory() as tmpdir:
             worktree_path = Path(tmpdir) / "nonexistent"
@@ -264,7 +268,9 @@ class TestOperationRemove(unittest.TestCase):
         """Test removing worktree with uncommitted changes."""
         mock_list.return_value = {
             "success": True,
-            "worktrees": [{"path": "/test/path", "branch": "test", "uncommittedChanges": True}],
+            "worktrees": [
+                {"path": "/test/path", "branch": "test", "uncommittedChanges": True}
+            ],
         }
 
         result = operation_remove("test", force=False)
@@ -278,7 +284,9 @@ class TestOperationRemove(unittest.TestCase):
         """Test successful worktree removal."""
         mock_list.return_value = {
             "success": True,
-            "worktrees": [{"path": "/test/path", "branch": "test", "uncommittedChanges": False}],
+            "worktrees": [
+                {"path": "/test/path", "branch": "test", "uncommittedChanges": False}
+            ],
         }
         mock_git.return_value = ("", True)
 
@@ -343,6 +351,29 @@ class TestOperationUpdateAll(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertEqual(result["totalWorktrees"], 1)
         self.assertEqual(result["successCount"], 1)
+
+    @patch("worktree_operations.subprocess.run")
+    @patch("worktree_operations.run_git_command")
+    @patch("worktree_operations.operation_list")
+    def test_update_all_install_uses_list_args(self, mock_list, mock_git, mock_run):
+        """Test npm install uses list args without shell=True."""
+        mock_list.return_value = {
+            "success": True,
+            "worktrees": [{"path": "/test/path", "branch": "test"}],
+        }
+        mock_git.return_value = ("Already up to date", True)
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("pathlib.Path.exists", return_value=True):
+            result = operation_update_all(install=True)
+
+        self.assertTrue(result["success"])
+        mock_run.assert_called_with(
+            ["npm", "install"],
+            cwd="/test/path",
+            capture_output=True,
+            text=True,
+        )
 
 
 class TestOperationPrune(unittest.TestCase):


### PR DESCRIPTION
## Description

Replace `shell=True` with list args for `npm install` in pop-worktree-manager and add a regression test.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test addition/update

## Related Issues

Closes #263

## Changes Made

- Use list args for `npm install` in worktree update
- Add test ensuring `subprocess.run` is called without shell usage

## Plugin Impact

- [ ] popkit-core
- [x] popkit-dev
- [ ] popkit-ops
- [ ] popkit-research
- [ ] shared-py
- [ ] cloud (private)
- [ ] None (documentation/CI only)

## Testing Performed

### Manual Testing

- [ ] Tested locally with `/plugin install ./packages/<plugin-name>`
- [ ] Verified in Claude Code (version: **__**)
- [ ] Tested affected commands/skills/agents

### Automated Testing

- [ ] Plugin tests passed (`python run_all_tests.py`)
- [x] Specific test category: **worktree operation unit tests**

### Test Results

```
python packages/popkit-dev/tests/test_worktree_operations.py
```

## Screenshots

N/A

## Checklist

### Code Quality

- [x] Code follows existing patterns and conventions
- [x] No hardcoded secrets or sensitive data
- [x] Paths use forward slashes and `${CLAUDE_PLUGIN_ROOT}` where applicable
- [x] Python hooks follow JSON stdin/stdout protocol
- [x] Conventional commit format used (feat:, fix:, docs:, etc.)

### Testing & Validation

- [ ] Plugin tests pass (`python run_all_tests.py`)
- [ ] CI checks pass (plugin validation, agents, hooks)
- [ ] No IP leaks detected (IP scanner check)
- [ ] Manual testing completed
- [x] Tests added/updated for new functionality (if applicable)

### Documentation

- [ ] Documentation updated (README, CLAUDE.md, etc.)
- [ ] CHANGELOG.md updated with version and changes
- [ ] Comments added for complex logic
- [ ] Plugin manifest updated (if adding commands/skills/agents)

### Breaking Changes

- [x] No breaking changes introduced

### Plugin-Specific (if applicable)

- [ ] Command YAML frontmatter is valid
- [ ] Skill SKILL.md format follows standards
- [ ] Agent AGENT.md includes purpose, triggers, capabilities
- [ ] Hook execution tested (timeout, error handling)

## Additional Context

N/A

---

## For Reviewers

### Review Focus Areas

- `npm install` call uses list args and avoids shell usage

### Testing Instructions

1. Run `python packages/popkit-dev/tests/test_worktree_operations.py`

### Known Limitations

N/A
