### PR TITLE
feat(power-mode): implement Issue #269 agent lifecycle events

### DIFF
--- a/packages/popkit-core/power-mode/lifecycle.py
+++ b/packages/popkit-core/power-mode/lifecycle.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+Power Mode agent lifecycle event system.
+
+Issue #269 introduces event-driven state transitions so coordinator logic can
+stay decoupled from side effects (logging, dashboards, automation hooks).
+"""
+
+from collections import defaultdict
+from datetime import datetime, timezone
+from enum import Enum
+from threading import RLock
+from typing import Any, Callable, DefaultDict, Dict, List, Optional, Union
+
+
+class LifecycleEvent(str, Enum):
+    """Supported lifecycle event names."""
+
+    AGENT_SPAWNED = "agent:spawned"
+    AGENT_IDLE = "agent:idle"
+    AGENT_STATE_CHANGED = "agent:state_changed"
+    PLAN_APPROVAL_REQUEST = "plan:approval_request"
+    PERMISSION_REQUEST = "permission:request"
+    TASK_COMPLETED = "task:completed"
+    AGENT_EXITED = "agent:exited"
+
+
+class AgentState(str, Enum):
+    """Canonical agent execution states."""
+
+    SPAWNED = "spawned"
+    RUNNING = "running"
+    IDLE = "idle"
+    PLANNING = "planning"
+    AWAITING_APPROVAL = "awaiting_approval"
+    EXITED = "exited"
+
+
+VALID_STATE_TRANSITIONS: Dict[AgentState, set[AgentState]] = {
+    AgentState.SPAWNED: {AgentState.RUNNING, AgentState.EXITED},
+    AgentState.RUNNING: {
+        AgentState.IDLE,
+        AgentState.PLANNING,
+        AgentState.AWAITING_APPROVAL,
+        AgentState.EXITED,
+    },
+    AgentState.IDLE: {AgentState.RUNNING, AgentState.PLANNING, AgentState.EXITED},
+    AgentState.PLANNING: {
+        AgentState.RUNNING,
+        AgentState.AWAITING_APPROVAL,
+        AgentState.EXITED,
+    },
+    AgentState.AWAITING_APPROVAL: {AgentState.RUNNING, AgentState.EXITED},
+    AgentState.EXITED: set(),
+}
+
+
+LifecycleHandler = Callable[[str], None]
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_event(event: Union[LifecycleEvent, str]) -> str:
+    return event.value if isinstance(event, LifecycleEvent) else str(event)
+
+
+def _normalize_state(state: Union[AgentState, str]) -> AgentState:
+    if isinstance(state, AgentState):
+        return state
+    return AgentState(state)
+
+
+class AgentLifecycle:
+    """Event emitter + state machine for power-mode agent lifecycle."""
+
+    def __init__(self, max_history: int = 500):
+        self.max_history = max_history
+        self._handlers: DefaultDict[str, List[Callable[..., None]]] = defaultdict(list)
+        self._states: Dict[str, AgentState] = {}
+        self._history: List[Dict[str, Any]] = []
+        self._lock = RLock()
+
+    def on(
+        self, event: Union[LifecycleEvent, str], handler: Callable[..., None]
+    ) -> None:
+        """Register an event handler."""
+        event_name = _normalize_event(event)
+        with self._lock:
+            self._handlers[event_name].append(handler)
+
+    def off(
+        self, event: Union[LifecycleEvent, str], handler: Callable[..., None]
+    ) -> None:
+        """Unregister an event handler."""
+        event_name = _normalize_event(event)
+        with self._lock:
+            handlers = self._handlers.get(event_name, [])
+            if handler in handlers:
+                handlers.remove(handler)
+
+    def emit(self, event: Union[LifecycleEvent, str], agent: str, **data: Any) -> int:
+        """Emit an event and invoke subscribed handlers."""
+        event_name = _normalize_event(event)
+
+        with self._lock:
+            handlers = list(self._handlers.get(event_name, []))
+            self._history.append(
+                {
+                    "timestamp": _utc_timestamp(),
+                    "event": event_name,
+                    "agent": agent,
+                    "data": data,
+                }
+            )
+            if len(self._history) > self.max_history:
+                self._history = self._history[-self.max_history :]
+
+        for handler in handlers:
+            handler(agent, **data)
+
+        return len(handlers)
+
+    def can_transition(
+        self,
+        agent: str,
+        new_state: Union[AgentState, str],
+    ) -> bool:
+        """Check whether an agent can move to a new state."""
+        target = _normalize_state(new_state)
+        current = self._states.get(agent)
+
+        if current is None:
+            return target == AgentState.SPAWNED
+        if current == target:
+            return True
+
+        return target in VALID_STATE_TRANSITIONS[current]
+
+    def set_state(
+        self,
+        agent: str,
+        new_state: Union[AgentState, str],
+        **metadata: Any,
+    ) -> AgentState:
+        """Transition an agent to a new state and emit lifecycle events."""
+        target = _normalize_state(new_state)
+
+        if not self.can_transition(agent, target):
+            current = self._states.get(agent)
+            current_value = current.value if current else "none"
+            raise ValueError(
+                f"Invalid state transition for {agent}: {current_value} -> {target.value}"
+            )
+
+        old_state = self._states.get(agent)
+        self._states[agent] = target
+
+        self.emit(
+            LifecycleEvent.AGENT_STATE_CHANGED,
+            agent,
+            old_state=old_state.value if old_state else None,
+            new_state=target.value,
+            **metadata,
+        )
+
+        if target == AgentState.SPAWNED:
+            self.emit(LifecycleEvent.AGENT_SPAWNED, agent, **metadata)
+        elif target == AgentState.IDLE:
+            self.emit(LifecycleEvent.AGENT_IDLE, agent, **metadata)
+        elif target == AgentState.EXITED:
+            self.emit(LifecycleEvent.AGENT_EXITED, agent, **metadata)
+
+        return target
+
+    def mark_permission_requested(
+        self, agent: str, request_id: str, **data: Any
+    ) -> None:
+        """Emit permission request event."""
+        self.emit(
+            LifecycleEvent.PERMISSION_REQUEST,
+            agent,
+            request_id=request_id,
+            **data,
+        )
+
+    def mark_plan_approval_requested(
+        self, agent: str, request_id: str, **data: Any
+    ) -> None:
+        """Emit plan approval request event."""
+        self.emit(
+            LifecycleEvent.PLAN_APPROVAL_REQUEST,
+            agent,
+            request_id=request_id,
+            **data,
+        )
+
+    def mark_task_completed(self, agent: str, task_id: str, **data: Any) -> None:
+        """Emit task completed event."""
+        self.emit(
+            LifecycleEvent.TASK_COMPLETED,
+            agent,
+            task_id=task_id,
+            **data,
+        )
+
+    def get_state(self, agent: str) -> Optional[AgentState]:
+        """Get current state for an agent."""
+        return self._states.get(agent)
+
+    def running_agents(self) -> List[str]:
+        """Get all currently non-exited agents."""
+        return [
+            agent for agent, state in self._states.items() if state != AgentState.EXITED
+        ]
+
+    def recent_events(self, limit: int = 25) -> List[Dict[str, Any]]:
+        """Return recent event history entries."""
+        if limit <= 0:
+            return []
+        return self._history[-limit:]
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Return JSON-serializable lifecycle snapshot."""
+        return {
+            "states": {agent: state.value for agent, state in self._states.items()},
+            "event_count": len(self._history),
+            "recent_events": self.recent_events(limit=10),
+        }

--- a/packages/popkit-core/power-mode/start_session.py
+++ b/packages/popkit-core/power-mode/start_session.py
@@ -12,6 +12,7 @@ from pathlib import Path
 # Add power-mode to path
 sys.path.insert(0, str(Path(__file__).parent))
 
+from lifecycle import AgentLifecycle, AgentState
 from protocol import MessageFactory, create_objective
 from upstash_adapter import get_redis_client, is_upstash_available
 
@@ -44,6 +45,11 @@ def start_power_mode_session(objective_text: str, issues: list):
     # Create session ID
     session_id = f"power-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
 
+    # Initialize lifecycle state for coordinator
+    lifecycle = AgentLifecycle()
+    lifecycle.set_state("coordinator", AgentState.SPAWNED, session_id=session_id)
+    lifecycle.set_state("coordinator", AgentState.RUNNING, session_id=session_id)
+
     # Create objective
     objective = create_objective(
         description=objective_text,
@@ -69,6 +75,7 @@ def start_power_mode_session(objective_text: str, issues: list):
         "agents": [],
         "insights": [],
         "phase": "initializing",
+        "lifecycle": lifecycle.snapshot(),
     }
 
     # Store session in Redis
@@ -122,6 +129,7 @@ def start_power_mode_session(objective_text: str, issues: list):
         "agents": [],
         "upstash_url": os.getenv("UPSTASH_REDIS_REST_URL"),
         "last_updated": datetime.now().isoformat(),
+        "lifecycle": lifecycle.snapshot(),
     }
 
     with open(state_file, "w") as f:
@@ -144,6 +152,7 @@ def start_power_mode_session(objective_text: str, issues: list):
         "session_id": session_id,
         "redis_client": redis_client,
         "channels": channels,
+        "lifecycle": lifecycle.snapshot(),
     }
 
 

--- a/packages/popkit-core/tests/power_mode/test_lifecycle.py
+++ b/packages/popkit-core/tests/power_mode/test_lifecycle.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Tests for Issue #269 lifecycle event system."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+POWER_MODE_DIR = Path(__file__).resolve().parents[2] / "power-mode"
+sys.path.insert(0, str(POWER_MODE_DIR))
+
+from lifecycle import AgentLifecycle, AgentState, LifecycleEvent  # noqa: E402
+
+
+def test_emit_invokes_registered_handlers():
+    lifecycle = AgentLifecycle()
+    seen = []
+
+    def handler(agent: str, **_: object) -> None:
+        seen.append(agent)
+
+    lifecycle.on(LifecycleEvent.AGENT_IDLE, handler)
+    lifecycle.emit(LifecycleEvent.AGENT_IDLE, "agent-1")
+
+    assert seen == ["agent-1"]
+
+
+def test_set_state_emits_state_changed_event():
+    lifecycle = AgentLifecycle()
+    transitions = []
+
+    def on_state_changed(agent: str, **data: object) -> None:
+        transitions.append((agent, data.get("old_state"), data.get("new_state")))
+
+    lifecycle.on(LifecycleEvent.AGENT_STATE_CHANGED, on_state_changed)
+
+    lifecycle.set_state("agent-1", AgentState.SPAWNED)
+    lifecycle.set_state("agent-1", AgentState.RUNNING)
+
+    assert transitions[0] == ("agent-1", None, "spawned")
+    assert transitions[1] == ("agent-1", "spawned", "running")
+
+
+def test_invalid_transition_raises_error():
+    lifecycle = AgentLifecycle()
+    lifecycle.set_state("agent-1", AgentState.SPAWNED)
+    lifecycle.set_state("agent-1", AgentState.RUNNING)
+    lifecycle.set_state("agent-1", AgentState.EXITED)
+
+    with pytest.raises(ValueError):
+        lifecycle.set_state("agent-1", AgentState.RUNNING)
+
+
+def test_spawn_idle_exit_emit_specific_events():
+    lifecycle = AgentLifecycle()
+    events = []
+
+    def on_any(agent: str, **_: object) -> None:
+        events.append(agent)
+
+    lifecycle.on(LifecycleEvent.AGENT_SPAWNED, on_any)
+    lifecycle.on(LifecycleEvent.AGENT_IDLE, on_any)
+    lifecycle.on(LifecycleEvent.AGENT_EXITED, on_any)
+
+    lifecycle.set_state("agent-1", AgentState.SPAWNED)
+    lifecycle.set_state("agent-1", AgentState.RUNNING)
+    lifecycle.set_state("agent-1", AgentState.IDLE)
+    lifecycle.set_state("agent-1", AgentState.EXITED)
+
+    assert events == ["agent-1", "agent-1", "agent-1"]
+
+
+def test_permission_and_plan_request_events_include_request_id():
+    lifecycle = AgentLifecycle()
+    emitted = []
+
+    def recorder(agent: str, **data: object) -> None:
+        emitted.append((agent, data.get("request_id")))
+
+    lifecycle.on(LifecycleEvent.PERMISSION_REQUEST, recorder)
+    lifecycle.on(LifecycleEvent.PLAN_APPROVAL_REQUEST, recorder)
+
+    lifecycle.mark_permission_requested("agent-1", "req-1", tool_name="Bash")
+    lifecycle.mark_plan_approval_requested("agent-1", "req-2", summary="plan")
+
+    assert emitted == [("agent-1", "req-1"), ("agent-1", "req-2")]
+
+
+def test_snapshot_is_json_serializable_shape():
+    lifecycle = AgentLifecycle()
+    lifecycle.set_state("agent-1", AgentState.SPAWNED)
+    lifecycle.set_state("agent-1", AgentState.RUNNING)
+
+    snapshot = lifecycle.snapshot()
+
+    assert snapshot["states"]["agent-1"] == "running"
+    assert snapshot["event_count"] >= 2
+    assert isinstance(snapshot["recent_events"], list)


### PR DESCRIPTION
## Summary
- add `power-mode/lifecycle.py` with event emitter + state machine for Power Mode agents
- define canonical lifecycle events (`agent:spawned`, `agent:idle`, `agent:state_changed`, `plan:approval_request`, `permission:request`, `task:completed`, `agent:exited`)
- enforce valid state transitions via `AgentLifecycle.set_state(...)`
- integrate lifecycle snapshot into `start_session.py` session/local state
- add tests in `tests/power_mode/test_lifecycle.py`

## Validation
- `ruff check packages/popkit-core/power-mode/lifecycle.py packages/popkit-core/power-mode/start_session.py packages/popkit-core/tests/power_mode/test_lifecycle.py`
- `pytest packages/popkit-core/tests/power_mode/test_protocol.py packages/popkit-core/tests/power_mode/test_lifecycle.py -q`
- `python packages/popkit-core/run_all_tests.py` (core plugin passes; existing non-blocking popkit-dev pytest failures unchanged)
