### PR TITLE
fix(popkit-next): prevent stale branch continuation recommendations

### DIFF
--- a/packages/popkit-dev/skills/pop-next-action/scripts/analyze_state.py
+++ b/packages/popkit-dev/skills/pop-next-action/scripts/analyze_state.py
@@ -372,7 +372,12 @@ def analyze_feature_branches(repo_root: Path) -> Dict[str, Any]:
     """Analyze feature/fix branches with work in progress."""
     import re
 
-    state = {"has_feature_branches": False, "branches": [], "urgency": "LOW"}
+    state = {
+        "has_feature_branches": False,
+        "branches": [],
+        "stale_branches": [],
+        "urgency": "LOW",
+    }
 
     # Get all local branches
     branches, ok = run_command(["git", "branch"], cwd=str(repo_root))
@@ -399,6 +404,39 @@ def analyze_feature_branches(repo_root: Path) -> Dict[str, Any]:
         issue_match = re.search(issue_pattern, branch)
         issue_number = int(issue_match.group(1)) if issue_match else None
 
+        # Skip branches that track a deleted upstream (usually merged/abandoned).
+        upstream_ref, _ = run_command(
+            [
+                "git",
+                "for-each-ref",
+                "--format=%(upstream:short)",
+                f"refs/heads/{branch}",
+            ],
+            cwd=str(repo_root),
+        )
+        upstream_track, _ = run_command(
+            [
+                "git",
+                "for-each-ref",
+                "--format=%(upstream:track)",
+                f"refs/heads/{branch}",
+            ],
+            cwd=str(repo_root),
+        )
+        upstream_ref = upstream_ref.strip()
+        upstream_track = upstream_track.strip()
+
+        if "gone" in upstream_track.lower():
+            state["stale_branches"].append(
+                {
+                    "name": branch,
+                    "upstream": upstream_ref,
+                    "upstream_status": upstream_track,
+                    "issue_number": issue_number,
+                }
+            )
+            continue
+
         # Get last commit date and message
         date_output, _ = run_command(
             ["git", "log", "-1", "--format=%ar", branch], cwd=str(repo_root)
@@ -421,6 +459,8 @@ def analyze_feature_branches(repo_root: Path) -> Dict[str, Any]:
             "last_commit": msg_output or "",
             "commits_ahead": commits_ahead,
             "issue_number": issue_number,
+            "upstream": upstream_ref,
+            "upstream_status": upstream_track,
         }
 
         state["branches"].append(branch_info)

--- a/packages/popkit-dev/skills/pop-next-action/scripts/recommend_action.py
+++ b/packages/popkit-dev/skills/pop-next-action/scripts/recommend_action.py
@@ -28,6 +28,7 @@ BASE_PRIORITIES = {
     "fix_build_errors": 90,
     "process_research": 85,
     "commit_work": 80,
+    "cleanup_stale_branches": 55,
     "push_changes": 60,
     "work_on_issue": 50,
     "tackle_tech_debt": 40,
@@ -306,6 +307,30 @@ def calculate_action_scores(state: Dict[str, Any]) -> List[Dict[str, Any]]:
 
     # Continue work on feature branches
     branches = state.get("branches", {})
+    stale_branches = branches.get("stale_branches", [])
+
+    if stale_branches:
+        score = BASE_PRIORITIES["cleanup_stale_branches"]
+        if branches.get("has_feature_branches"):
+            score -= 10
+
+        actions.append(
+            {
+                "id": "review_stale_branches",
+                "name": "Review Stale Local Branches",
+                "command": "git branch -vv",
+                "score": score,
+                "why": (
+                    f"{len(stale_branches)} feature/fix branch(es) track deleted upstreams"
+                ),
+                "what": (
+                    "Confirm merged status and delete stale local branches that are no longer needed"
+                ),
+                "benefit": "Cleaner local context and better next-action recommendations",
+                "stale_branches": stale_branches,
+            }
+        )
+
     if branches.get("has_feature_branches") and branches.get("branches"):
         # Sort by commits ahead (most work = highest priority)
         sorted_branches = sorted(


### PR DESCRIPTION
## Summary
- Stop `popkit-next` from recommending local feature/fix branches whose tracked upstream is `[gone]`.
- Surface stale branches as a cleanup recommendation instead of a false “continue work” recommendation.

## Why
A `popkit-next` dry run recommended `fix/security-final-two-alerts` even though its remote tracking branch was deleted (already merged/obsolete). That produced a misleading top recommendation.

## Changes
- `packages/popkit-dev/skills/pop-next-action/scripts/analyze_state.py`
  - Track `stale_branches` in feature branch analysis.
  - Mark branches with upstream status containing `gone` as stale.
  - Exclude stale branches from active “continue work” candidates.
  - Include upstream metadata in branch context.
- `packages/popkit-dev/skills/pop-next-action/scripts/recommend_action.py`
  - Add `Review Stale Local Branches` recommendation when stale branches exist.
  - Keep normal continuation behavior for non-stale active branches.

## Validation
- `ruff check packages/popkit-dev/skills/pop-next-action/scripts/analyze_state.py packages/popkit-dev/skills/pop-next-action/scripts/recommend_action.py`
- Reran `popkit-next` dry run and confirmed stale branch is no longer the top recommendation.

## First-principles note
If “next action” suggestions are wrong, the workflow loses trust quickly. This patch improves recommendation correctness before adding more capability.