### PR TITLE
feat(dev): add hybrid delegation router for issue #218

### DIFF
--- a/packages/popkit-dev/commands/dev.md
+++ b/packages/popkit-dev/commands/dev.md
@@ -77,6 +77,11 @@ Use explicit overrides for experimentation:
 - `--provider popkit` - force native PopKit orchestration
 - `--provider feature-dev` - force upstream workflow (fallback to PopKit if unavailable)
 
+Implementation references:
+
+- `packages/shared-py/popkit_shared/utils/dev_provider_resolver.py`
+- `packages/shared-py/popkit_shared/utils/dev_workflow_router.py`
+
 ---
 
 ## Mode: full

--- a/packages/shared-py/popkit_shared/utils/dev_workflow_router.py
+++ b/packages/shared-py/popkit_shared/utils/dev_workflow_router.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Issue #218: Hybrid PopKit/feature-dev execution planning.
+
+Builds an executable plan from provider resolution:
+- native PopKit execution path
+- delegated feature-dev path with PopKit fallback
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from .dev_provider_resolver import (
+    DevProvider,
+    DevProviderResolver,
+    ProviderAvailability,
+    ProviderContext,
+    ProviderDecision,
+    detect_feature_dev_plugin,
+)
+
+VALID_MODES = {"quick", "full"}
+
+
+def _normalize_mode(mode: str) -> str:
+    normalized = (mode or "").strip().lower()
+    if normalized in VALID_MODES:
+        return normalized
+    return "full"
+
+
+def _escape_for_double_quotes(value: str) -> str:
+    return value.replace('"', '\\"')
+
+
+@dataclass(frozen=True)
+class DevWorkflowRequest:
+    """Inputs for building a dev workflow execution plan."""
+
+    task: str
+    mode: str = "full"
+    issue_number: Optional[int] = None
+    requested_provider: DevProvider = DevProvider.AUTO
+    allow_upstream: bool = True
+    requires_popkit_orchestration: bool = False
+    requires_github_cache: bool = False
+
+
+@dataclass
+class DevWorkflowPlan:
+    """Executable plan for the selected development provider."""
+
+    decision: ProviderDecision
+    execution_mode: str  # "native" | "delegated"
+    primary_command: str
+    fallback_command: Optional[str] = None
+    notes: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "decision": self.decision.to_dict(),
+            "execution_mode": self.execution_mode,
+            "primary_command": self.primary_command,
+            "fallback_command": self.fallback_command,
+            "notes": self.notes,
+        }
+
+
+class DevWorkflowRouter:
+    """Resolve provider and build a runnable workflow plan."""
+
+    def __init__(self, resolver: Optional[DevProviderResolver] = None):
+        self.resolver = resolver or DevProviderResolver()
+
+    def build_plan(
+        self,
+        request: DevWorkflowRequest,
+        plugin_scan_data: Optional[Any] = None,
+    ) -> DevWorkflowPlan:
+        required_capabilities = set()
+        if request.requires_popkit_orchestration:
+            required_capabilities.add("worktree_orchestration")
+        if request.requires_github_cache:
+            required_capabilities.add("issue_guidance")
+
+        availability = ProviderAvailability(
+            feature_dev_available=detect_feature_dev_plugin(plugin_scan_data),
+            popkit_available=True,
+        )
+        context = ProviderContext(
+            requested_provider=request.requested_provider,
+            required_capabilities=required_capabilities,
+            allow_upstream=request.allow_upstream,
+            workflow_mode=_normalize_mode(request.mode),
+        )
+        decision = self.resolver.resolve(context, availability)
+        normalized_mode = _normalize_mode(request.mode)
+
+        popkit_command = self._build_popkit_command(
+            task=request.task,
+            mode=normalized_mode,
+            issue_number=request.issue_number,
+        )
+        notes: List[str] = []
+        if request.task.strip():
+            notes.append(f"Task context: {request.task.strip()}")
+        if request.issue_number is not None:
+            notes.append(f"Issue context: #{request.issue_number}")
+
+        if decision.selected_provider == DevProvider.FEATURE_DEV:
+            notes.append("Run PopKit enhancement hooks after delegated feature-dev execution.")
+            return DevWorkflowPlan(
+                decision=decision,
+                execution_mode="delegated",
+                primary_command="/popkit:feature-dev",
+                fallback_command=popkit_command,
+                notes=notes,
+            )
+
+        return DevWorkflowPlan(
+            decision=decision,
+            execution_mode="native",
+            primary_command=popkit_command,
+            fallback_command=None,
+            notes=notes,
+        )
+
+    @staticmethod
+    def _build_popkit_command(task: str, mode: str, issue_number: Optional[int]) -> str:
+        if issue_number is not None:
+            target = f"work #{issue_number}"
+        else:
+            task_text = _escape_for_double_quotes(task.strip())
+            target = f'"{task_text}"'
+
+        return f"/popkit-dev:dev {target} --mode {mode} --provider popkit"

--- a/packages/shared-py/tests/utils/test_dev_workflow_router.py
+++ b/packages/shared-py/tests/utils/test_dev_workflow_router.py
@@ -1,0 +1,85 @@
+"""Tests for dev_workflow_router.py (Issue #218)."""
+
+from popkit_shared.utils.dev_provider_resolver import DevProvider
+from popkit_shared.utils.dev_workflow_router import DevWorkflowRequest, DevWorkflowRouter
+
+
+def test_build_plan_auto_prefers_feature_dev_for_commodity_paths():
+    router = DevWorkflowRouter()
+    request = DevWorkflowRequest(
+        task="add auth flow",
+        requested_provider=DevProvider.AUTO,
+        requires_popkit_orchestration=False,
+        requires_github_cache=False,
+    )
+    plugins = [{"name": "feature-dev"}]
+
+    plan = router.build_plan(request, plugin_scan_data=plugins)
+
+    assert plan.execution_mode == "delegated"
+    assert plan.primary_command == "/popkit:feature-dev"
+    assert plan.fallback_command is not None
+    assert "--provider popkit" in plan.fallback_command
+    assert plan.decision.selected_provider == DevProvider.FEATURE_DEV
+
+
+def test_build_plan_auto_forces_popkit_when_popkit_capability_required():
+    router = DevWorkflowRouter()
+    request = DevWorkflowRequest(
+        task="complex orchestration",
+        requested_provider=DevProvider.AUTO,
+        requires_popkit_orchestration=True,
+    )
+    plugins = [{"name": "feature-dev"}]
+
+    plan = router.build_plan(request, plugin_scan_data=plugins)
+
+    assert plan.execution_mode == "native"
+    assert plan.primary_command.startswith("/popkit-dev:dev")
+    assert "--provider popkit" in plan.primary_command
+    assert plan.decision.selected_provider == DevProvider.POPKIT
+
+
+def test_build_plan_explicit_feature_dev_falls_back_when_unavailable():
+    router = DevWorkflowRouter()
+    request = DevWorkflowRequest(
+        task="add telemetry",
+        requested_provider=DevProvider.FEATURE_DEV,
+    )
+
+    plan = router.build_plan(request, plugin_scan_data=[])
+
+    assert plan.execution_mode == "native"
+    assert plan.primary_command.startswith("/popkit-dev:dev")
+    assert any(
+        "feature-dev was requested but unavailable" in reason for reason in plan.decision.rationale
+    )
+    assert plan.decision.selected_provider == DevProvider.POPKIT
+
+
+def test_build_plan_uses_issue_work_target_when_issue_number_provided():
+    router = DevWorkflowRouter()
+    request = DevWorkflowRequest(
+        task="",
+        issue_number=218,
+        requested_provider=DevProvider.POPKIT,
+    )
+
+    plan = router.build_plan(request, plugin_scan_data=[])
+
+    assert plan.primary_command.startswith("/popkit-dev:dev work #218")
+    assert "--mode full" in plan.primary_command
+    assert "--provider popkit" in plan.primary_command
+
+
+def test_build_plan_normalizes_invalid_mode_to_full():
+    router = DevWorkflowRouter()
+    request = DevWorkflowRequest(
+        task="stabilize ci",
+        mode="turbo",
+        requested_provider=DevProvider.POPKIT,
+    )
+
+    plan = router.build_plan(request, plugin_scan_data=[])
+
+    assert "--mode full" in plan.primary_command


### PR DESCRIPTION
## Summary
- add DevWorkflowRouter to turn provider resolution into executable workflow plans
- support native PopKit and delegated feature-dev flows with explicit fallback
- document router references in /popkit-dev:dev command docs

## Why
Issue #218 required more than provider selection. We also needed a concrete delegation wrapper so uto|popkit|feature-dev decisions can be translated into runnable commands.

## Changes
- packages/shared-py/popkit_shared/utils/dev_workflow_router.py
  - adds DevWorkflowRequest, DevWorkflowPlan, and DevWorkflowRouter
  - maps request flags to resolver equired_capabilities
  - returns delegated plans (/popkit:feature-dev) with PopKit fallback
  - returns native plans (/popkit-dev:dev ... --provider popkit) when resolver selects PopKit
- packages/shared-py/tests/utils/test_dev_workflow_router.py
  - validates auto selection, popkit-only capability forcing, explicit feature-dev fallback, issue-target command generation, and mode normalization
- packages/popkit-dev/commands/dev.md
  - adds implementation references for resolver + router

## Validation
- uff check packages/shared-py/popkit_shared/utils/dev_workflow_router.py packages/shared-py/tests/utils/test_dev_workflow_router.py
- python -m pytest packages/shared-py/tests/utils/test_dev_workflow_router.py -q

## First-principles note
Resolver logic alone is not enough to ship hybrid architecture. We need deterministic execution plans so operators can see exactly what command path will run and what fallback exists.