### PR TITLE
docs: clarify /popkit workflow vs /pop direct skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ It's the difference between "here's an AI" and "here's how to use AI to build so
 
 ---
 
+## Command Tiers
+
+PopKit intentionally exposes two layers:
+
+| Layer             | Prefix     | Purpose                                                      | Default  |
+| ----------------- | ---------- | ------------------------------------------------------------ | -------- |
+| Workflow commands | `/popkit-` | User-facing orchestration across commands, skills, and hooks | Yes      |
+| Direct skills     | `/pop-`    | Low-level primitives for targeted/advanced invocation        | Advanced |
+
+Example: `/popkit-dev:next` uses `pop-next-action` internally, then adds mode handling, reporting, and command-level guidance.
+
+---
+
 ## Get Started
 
 ```bash

--- a/packages/docs/src/content/docs/concepts/commands.md
+++ b/packages/docs/src/content/docs/concepts/commands.md
@@ -7,6 +7,17 @@ description: Slash commands for common workflows
 
 PopKit provides 25 slash commands for common development workflows. Commands are the primary interface for interacting with PopKit.
 
+## Two-Tier Model
+
+PopKit intentionally exposes both orchestration commands and direct skills:
+
+| Tier              | Prefix     | Purpose                                                      | Recommended |
+| ----------------- | ---------- | ------------------------------------------------------------ | ----------- |
+| Workflow commands | `/popkit-` | High-level flows that orchestrate skills, hooks, and scripts | Yes         |
+| Direct skills     | `/pop-`    | Low-level primitives for targeted/advanced usage             | Advanced    |
+
+Most users should start with `/popkit-*` commands and drop to `/pop-*` when they want precise, direct control.
+
 ## Core Commands
 
 ### Project Management
@@ -24,7 +35,7 @@ PopKit provides 25 slash commands for common development workflows. Commands are
 ### Development
 
 - `/popkit-dev:dev` - 7-phase feature development workflow
-- `/popkit-dev:work` - Work on specific GitHub issue
+- `/popkit-dev:issue` - GitHub issue management and execution flows
 - `/popkit-ops:debug` - Debug code or routing issues
 
 ### Routines
@@ -52,12 +63,12 @@ Examples:
 
 ## Command vs Skills
 
-| Commands              | Skills                   |
-| --------------------- | ------------------------ |
-| User-facing interface | Internal automation      |
-| Slash command syntax  | Invoked programmatically |
-| High-level workflows  | Low-level operations     |
-| Documentation focused | Implementation focused   |
+| Commands                                | Skills                                        |
+| --------------------------------------- | --------------------------------------------- |
+| User-facing workflows                   | Reusable primitives                           |
+| Usually `/popkit-*`                     | Usually `/pop-*` (or `/skill invoke <name>`)  |
+| Can orchestrate multiple skills + hooks | Focused on one domain capability              |
+| Stable entry points for daily usage     | Advanced/direct execution and building blocks |
 
 Commands often use multiple skills internally to accomplish their goals.
 
@@ -65,4 +76,4 @@ Commands often use multiple skills internally to accomplish their goals.
 
 - Learn about [Hooks](/concepts/hooks/)
 - Explore [Power Mode](/features/power-mode/)
-- Review command reference (coming in Phase 3)
+- Review [Commands Reference](/reference/commands/)

--- a/packages/docs/src/content/docs/concepts/skills.md
+++ b/packages/docs/src/content/docs/concepts/skills.md
@@ -5,42 +5,47 @@ description: Reusable automation workflows in PopKit
 
 # Skills
 
-Skills are reusable automation workflows that encapsulate common development tasks. PopKit includes 43 skills across various categories.
+Skills are reusable automation workflows that encapsulate common development tasks. PopKit currently includes 44 skills across 4 plugins.
 
 ## What are Skills?
 
-Skills in PopKit:
+Skills in PopKit are:
 
 - **Reusable**: Can be invoked from multiple contexts
 - **Composable**: Can call other skills
 - **Documented**: Include usage examples and parameters
 - **Testable**: Have defined input/output contracts
+- **Tiered**: Exposed directly (`/pop-*`) and through workflow commands (`/popkit-*`)
 
 ## Skill Categories
 
-### Development Workflows
+### Planning & Execution
 
-- `pop-feature-dev`: 7-phase feature development
-- `pop-brainstorming`: Design exploration and planning
-- `pop-work-on-issue`: GitHub issue workflow
+- `pop-brainstorming`: Design exploration and specification refinement
+- `pop-writing-plans`: Structured implementation plan generation
+- `pop-executing-plans`: Controlled batch execution with checkpoints
+- `pop-finish-branch`: End-of-work branch finalization flow
 
-### Git Operations
+### Routines & Context
 
-- `pop-git-commit`: Smart commit message generation
-- `pop-git-pr`: Pull request creation with context
-- `pop-git-publish`: Public repository publishing
+- `pop-morning`: Start-of-day health and readiness workflow
+- `pop-nightly`: End-of-day cleanup and session capture workflow
+- `pop-session-capture`: Persist working context for next session
+- `pop-session-resume`: Restore previous context
 
-### Project Management
+### Quality & Operations
 
-- `pop-next-action`: Context-aware next steps
-- `pop-morning`: Morning routine and health check
-- `pop-nightly`: End-of-day cleanup and summary
+- `pop-assessment-security`: Security posture assessment
+- `pop-code-review`: Risk-focused code review
+- `pop-systematic-debugging`: Structured debugging methodology
+- `pop-benchmark-runner`: Controlled benchmark and analysis runs
 
-### Analysis & Quality
+### Project & Platform
 
-- `pop-code-review`: Comprehensive code review
-- `pop-security-scan`: Security vulnerability detection
-- `pop-performance-audit`: Performance profiling
+- `pop-analyze-project`: Architecture and pattern analysis
+- `pop-project-init`: Project bootstrap and Claude config setup
+- `pop-project-reference`: Cross-project context loading
+- `pop-power-mode`: Multi-agent orchestration
 
 ## Using Skills
 
@@ -49,8 +54,8 @@ Skills can be invoked in several ways:
 ### From Commands
 
 ```bash
-/popkit-dev:git commit
-# Internally uses pop-git-commit skill
+/popkit-dev:next
+# Internally uses pop-next-action plus command-layer formatting/flow
 ```
 
 ### From Agents
@@ -60,8 +65,12 @@ Agents can invoke skills as part of their workflows.
 ### Directly (Advanced)
 
 ```bash
+/pop-next-action
+/pop-assessment-security
 /skill invoke pop-next-action
 ```
+
+Depending on Claude Code client version and settings, direct-skill entries may appear as bare `/pop-*` aliases or only via `/skill invoke`.
 
 ## Creating Custom Skills
 

--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -26,7 +26,8 @@ PopKit is an AI-powered development workflow system that orchestrates Claude Cod
     with multiple specialized agents.
   </Card>
   <Card title="Tiered Agent System" icon="puzzle">
-    43 skills, 25 commands, and 23 agents across 3 tiers - from always-active core tools to on-demand specialists.
+    44 skills, 25 commands, and 23 agents across 3 tiers - from always-active core tools to
+    on-demand specialists.
   </Card>
   <Card title="7-Phase Feature Development" icon="pencil">
     Structured workflow from discovery through architecture to implementation and review.
@@ -61,8 +62,9 @@ Day-bracketing workflow with health checks and cleanup, providing "Ready to Code
 ## Architecture
 
 PopKit is a configuration-only plugin leveraging:
+
 - **Agents**: 23 specialized agents with tiered activation
-- **Skills**: 43 reusable skills in SKILL.md format
+- **Skills**: 44 reusable skills in SKILL.md format
 - **Commands**: 25 slash commands for common workflows
 - **Hooks**: 23 Python hooks with JSON stdin/stdout protocol
 - **Output Styles**: 15+ templates for PRs, issues, reviews

--- a/packages/docs/src/content/docs/reference/commands.md
+++ b/packages/docs/src/content/docs/reference/commands.md
@@ -7,6 +7,8 @@ description: Complete reference for all PopKit commands
 
 PopKit provides 25 slash commands across 4 plugins for managing development workflows.
 
+These `/popkit-*` commands are the recommended entry points. For direct primitive invocation, see [Skills Reference](/reference/skills/) (`/pop-*` layer).
+
 ## popkit-core
 
 Core foundation commands for project management and orchestration.

--- a/packages/docs/src/content/docs/reference/skills.md
+++ b/packages/docs/src/content/docs/reference/skills.md
@@ -1,11 +1,27 @@
 ---
 title: Skills Reference
-description: Complete reference for all 43 PopKit skills
+description: Complete reference for all 44 PopKit skills
 ---
 
 # Skills Reference
 
-PopKit provides 43 reusable skills across 4 plugins. Skills are invoked via slash commands and provide specialized automation for common development tasks.
+PopKit provides 44 reusable skills across 4 plugins. Skills provide specialized automation for common development tasks.
+
+## Invocation Modes
+
+PopKit intentionally exposes skills in both direct and orchestrated forms:
+
+| Mode                    | Typical syntax                        | Use case                |
+| ----------------------- | ------------------------------------- | ----------------------- |
+| Workflow command        | `/popkit-<plugin>:<command>`          | Daily/default usage     |
+| Direct skill invocation | `/pop-...` or `/skill invoke pop-...` | Advanced/targeted usage |
+
+Examples:
+
+- `/popkit-dev:next` wraps `pop-next-action` with command-level parsing and formatted output.
+- `/popkit-ops:assess security` routes into the `pop-assessment-security` skill.
+
+Note: depending on client/version, you may see direct-skill entries as bare `/pop-*` aliases.
 
 ## popkit-core (15 skills)
 


### PR DESCRIPTION
Summary:
- clarify two-tier model: /popkit-* workflow commands vs /pop-* direct skills
- document that both layers are intentionally exposed
- update stale skill count from 43 to 44
- align concept/reference docs with recommended default usage

Why:
Users are seeing mixed /popkit-* and /pop-* entries in command palettes. This PR makes the distinction explicit without hiding direct skills.

Validation:
- npx prettier --check on updated docs files
- npm run docs:build