### PR TITLE
docs(skills): add skill-authoring standard and rubric template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -285,17 +285,16 @@
       }
     },
     "node_modules/@astrojs/telemetry": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
-      "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.1.tgz",
+      "integrity": "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw==",
       "license": "MIT",
       "dependencies": {
-        "ci-info": "^4.2.0",
-        "debug": "^4.4.0",
+        "ci-info": "^4.4.0",
         "dlv": "^1.1.3",
         "dset": "^3.1.4",
-        "is-docker": "^3.0.0",
-        "is-wsl": "^3.1.0",
+        "is-docker": "^4.0.0",
+        "is-wsl": "^3.1.1",
         "which-pm-runs": "^1.1.0"
       },
       "engines": {
@@ -2565,9 +2564,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
-      "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2998,15 +2997,15 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.4.tgz",
-      "integrity": "sha512-SRy1bONuCHkGWhI5JiWCQKVDVbeaXOikjAVZs/Nz+lvUvubtdLoZfnacmuZHQ9RL2IOkU54M8/qZYm9ypJDKrg==",
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.9.tgz",
+      "integrity": "sha512-NsAHzMzpznB281g2aM5qnBt2QjfH6ttKiZ3hSZw52If8JJ+62kbnBKbyKhR2glQcJLl7Jfe4GSl0DihFZ36rRQ==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^3.0.1",
-        "@astrojs/internal-helpers": "0.8.0",
-        "@astrojs/markdown-remark": "7.1.0",
-        "@astrojs/telemetry": "3.3.0",
+        "@astrojs/internal-helpers": "0.9.0",
+        "@astrojs/markdown-remark": "7.1.1",
+        "@astrojs/telemetry": "3.3.1",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
         "@oslojs/encoding": "^1.1.0",
@@ -3019,7 +3018,6 @@
         "cookie": "^1.1.1",
         "devalue": "^5.6.3",
         "diff": "^8.0.3",
-        "dlv": "^1.1.3",
         "dset": "^3.1.4",
         "es-module-lexer": "^2.0.0",
         "esbuild": "^0.27.3",
@@ -3038,7 +3036,7 @@
         "p-queue": "^9.1.0",
         "package-manager-detector": "^1.6.0",
         "piccolore": "^0.1.3",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "rehype": "^13.0.2",
         "semver": "^7.7.4",
         "shiki": "^4.0.2",
@@ -3051,9 +3049,9 @@
         "ultrahtml": "^1.6.0",
         "unifont": "~0.7.4",
         "unist-util-visit": "^5.1.0",
-        "unstorage": "^1.17.4",
+        "unstorage": "^1.17.5",
         "vfile": "^6.0.3",
-        "vite": "^7.3.1",
+        "vite": "^7.3.2",
         "vitefu": "^1.1.2",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^22.0.0",
@@ -3085,6 +3083,44 @@
       },
       "peerDependencies": {
         "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta"
+      }
+    },
+    "node_modules/astro/node_modules/@astrojs/internal-helpers": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.0.tgz",
+      "integrity": "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.4"
+      }
+    },
+    "node_modules/astro/node_modules/@astrojs/markdown-remark": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.1.tgz",
+      "integrity": "sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.9.0",
+        "@astrojs/prism": "4.0.1",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "js-yaml": "^4.1.1",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.0",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
       }
     },
     "node_modules/astro/node_modules/@shikijs/core": {
@@ -3216,9 +3252,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.10",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
-      "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -3272,9 +3308,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3291,11 +3327,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3305,9 +3341,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3913,9 +3949,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.325",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.325.tgz",
-      "integrity": "sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==",
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "license": "ISC"
     },
     "node_modules/entities": {
@@ -5119,15 +5155,15 @@
       }
     },
     "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+      "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5179,6 +5215,21 @@
       },
       "engines": {
         "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5352,9 +5403,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.2.tgz",
-      "integrity": "sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -7005,9 +7056,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
-      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT",
       "peer": true
     },
@@ -7648,9 +7699,9 @@
       }
     },
     "node_modules/sitemap/node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -8628,7 +8679,7 @@
       "dependencies": {
         "@astrojs/react": "^5.0.3",
         "@astrojs/starlight": "^0.38.3",
-        "astro": "^6.1.4",
+        "astro": "^6.1.9",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "recharts": "^3.8.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6908,9 +6908,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "overrides": {
     "brace-expansion": "^5.0.5",
     "h3": "^1.15.5",
+    "postcss": "^8.5.10",
     "vite": "^7.3.2"
   }
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro check && astro build",
+    "build": "astro build",
     "preview": "astro preview",
     "astro": "astro"
   },
@@ -25,7 +25,7 @@
   "dependencies": {
     "@astrojs/react": "^5.0.3",
     "@astrojs/starlight": "^0.38.3",
-    "astro": "^6.1.4",
+    "astro": "^6.1.9",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "recharts": "^3.8.1"

--- a/packages/popkit-core/docs/SKILL_AUTHORING.md
+++ b/packages/popkit-core/docs/SKILL_AUTHORING.md
@@ -1,0 +1,205 @@
+# PopKit Skill Authoring Standard
+
+House style for writing `SKILL.md` under `packages/*/skills/*/`. The goal is skills that behave like protocols instead of prose: same shape every run, no silent scope reduction, measurable compliance.
+
+Inspired by [`ehmo/code-overhaul-skill`](https://github.com/ehmo/code-overhaul-skill), which pairs a rigid protocol with a binary grader and drives iteration off the grader's output.
+
+---
+
+## Why this exists
+
+Skills are instructions to an LLM. Vague instructions produce variable output; directives produce comparable output. This document is the minimum bar for new skills and the target for existing ones.
+
+Two invariants:
+
+1. Every user-visible artifact the skill emits has a **fixed schema** — templates, tables, and ASCII boxes with named slots, not prose.
+2. Every skill that makes recommendations ships with an **`eval/RUBRIC.md`** whose criteria are binary and the skill is scored against it before merge.
+
+---
+
+## 1. Frontmatter contract
+
+```yaml
+---
+name: <lowercase-hyphen-case>
+description: >
+  <directive verb> <what it does>. Use when <trigger phrase the user says>.
+  Do NOT use for <explicit non-goal>.
+argument-hint: "[mode] [path]" # only if the skill takes arguments
+allowed-tools: # only if the skill scopes its tools
+  - Read
+  - Grep
+  - Glob
+  - Bash
+---
+```
+
+Rules:
+
+- **`name`** matches the regex `^[a-z0-9-]+$` and matches the directory name. Enforced by `tests/skills/test-skill-format.json`.
+- **`description`** opens with a directive verb (the action), contains natural-language trigger phrases ("Use when ..."), and names at least one non-goal ("Do NOT use for ..."). Target ≤200 characters; 300 is the ceiling.
+- **`argument-hint`** lists every valid argument verbatim when arguments exist.
+- **`allowed-tools`** names every shell/file tool the skill actually calls. Built-ins (`AskUserQuestion`, `TodoWrite`) may be omitted.
+- No placeholder strings (`TODO`, `TBD`, `placeholder`) anywhere in frontmatter.
+
+## 2. Required sections
+
+H1 matches the skill's human name. Every skill includes at least two of:
+
+- `## When to Use`
+- `## When NOT to Use`
+- `## Process` (or `## Protocol` for audit-shaped skills)
+- `## Integration Points`
+
+Minimum section count is enforced by `tests/skills/test-skill-format.json`. `When NOT to Use` is mandatory when `description` contains "Do NOT use" — the section must expand the reasoning.
+
+## 3. Output schema discipline
+
+If the skill emits a report, finding, plan, or summary, publish its **exact shape** inside SKILL.md. Free-form output is forbidden.
+
+### 3.1 Finding template (for audit/review skills)
+
+```
+### Finding <section>.<n><letter>   [<module-tag>]
+
+Problem:    <one sentence, no hedging>
+Evidence:   <file:line> or <command that reproduces>
+Options:
+  A) <action>   — effort: S|M|L, risk: S|M|L, blast: S|M|L, maintenance: S|M|L
+  B) <action>   — effort: S|M|L, risk: S|M|L, blast: S|M|L, maintenance: S|M|L
+  Defer        — effort: 0, risk: 0, blast: 0, maintenance: 0, reason: <one line>
+Recommendation: <LETTER> — <one-sentence rationale tied to an engineering principle>
+```
+
+The Defer option is always present and always carries zero labels so the grammar is uniform.
+
+### 3.2 Report template (for capture/generator skills)
+
+Publish the exact structure the skill prints. Every field is named, every field has a source. No "…" or "etc." in the template — if a field is optional, label it `Optional:` explicitly.
+
+### 3.3 Summary box
+
+If a skill runs end-to-end over multiple steps, close with an ASCII summary box with named rows. No narrative prose in the summary — numbers and statuses only.
+
+## 4. Mode commitment (for multi-scope skills)
+
+Audit-shaped, generator-shaped, and refactor-shaped skills expose a **fixed set of modes** at the top and block until the user picks one. Mode caps are numeric.
+
+Recommended schema:
+
+| Mode         | Scope                           | Cap            |
+| ------------ | ------------------------------- | -------------- |
+| `surgical`   | One theme, one session          | ≤3 findings    |
+| `systematic` | Section-by-section, interactive | ≤4 per section |
+| `full`       | Exhaustive, phased roadmap      | no cap         |
+
+Scope drift is not silent: if the user expands scope mid-run, re-issue the mode question before complying.
+
+## 5. Batched confirmation
+
+Do **not** ask for approval after every finding. Emit all findings for a section, then fire **one** `AskUserQuestion` with three branches:
+
+- **Approve** → next section
+- **Revise** → re-emit the affected findings and re-ask
+- **Pause** → write the checkpoint file, jump to summary with `Status: paused`
+
+One prompt per section, not one prompt per finding. Measured impact: the code-overhaul skill reports "eliminates up to 20 prompts per full audit" after this change.
+
+## 6. Soft-verb ban
+
+Mandatory steps use directives. These verbs are banned from any step marked **must**, **required**, or mandatory:
+
+> `consider`, `evaluate`, `should`, `could`, `may`, `might`, `try to`, `attempt to`, `think about`
+
+Replace with: `do`, `run`, `stop`, `write`, `emit`, `file`, `assert`, `require`.
+
+Soft verbs are allowed only in descriptive glossaries, illustrative examples, or user-facing explanations of optional behavior.
+
+## 7. Hard gates
+
+Two invariants that catch the most common regressions. Include them verbatim in any audit/refactor skill.
+
+- **Characterization-tests-first:** if a recommendation touches untested code, the first execution step is the characterization-test plan, not the change.
+- **Failure-mode gate:** for every modified codepath, emit a row in a `codepath | failure | test? | handling? | visible?` table. `no + no + silent` is a **critical gap** with automatic priority uplift.
+
+## 8. Checkpointing (for multi-step skills)
+
+Skills that span more than three interactive sections write `.<skill-name>/resume.md` after each section-close resolves. Schema:
+
+```yaml
+version: <semver matching SKILL.md frontmatter>
+mode: surgical | systematic | full
+target: <absolute path>
+written_at: <ISO-8601>
+completed_sections: [1, 2, 3]
+next_section: 4
+findings:
+  - id: 2.1A
+    tag: <module-tag>
+    title: <one line>
+    chosen: A | B | Defer
+```
+
+Stale-file rule: if `written_at` is older than 7 days, prompt fresh-vs-resume on invocation. Document the staleness threshold in SKILL.md; do not hardcode a different value.
+
+## 9. Eval harness
+
+Every skill that makes recommendations ships a grading kit:
+
+```
+packages/<pkg>/skills/<skill>/
+├── SKILL.md
+└── eval/
+    ├── RUBRIC.md      # binary criteria, 1 point each, no partial credit
+    ├── GRADER.md      # grader prompt (read RUBRIC, read SKILL, score)
+    └── SCENARIOS.md   # optional: 3-5 real-repo walk-throughs
+```
+
+Rubric rules:
+
+- Criteria are **binary** (0 or 1). No half credit. Partial matches score 0.
+- Every criterion is checkable against SKILL.md text alone — a grader with no other context can score it.
+- Target score is `N/N`. Failing criteria are gaps to fix before merge.
+- When SKILL.md changes, re-run the grader before the PR lands. Grader output goes in the PR description.
+
+See `packages/popkit-core/docs/skill-template/eval/` for the template.
+
+## 10. Versioning (for skills with on-disk state or public protocols)
+
+Skills that write files, emit artifacts, or publish slash-commands users rely on follow semver:
+
+- **MAJOR** — protocol-breaking (changes to argument shape, on-disk schema, or required tool set).
+- **MINOR** — additive (new modes, new sections, new addendums).
+- **PATCH** — clarifications, soft-verb scrubs, rubric fixes.
+
+Track version in SKILL.md frontmatter (`version: 2.1.0`). Maintain a sibling `CHANGELOG.md` in the skill directory if the skill is versioned. Mark protocol-breaking changes explicitly — on-disk state written by an older version must either be readable or trigger a fresh-vs-resume prompt.
+
+## 11. Pre-merge checklist
+
+Before opening a PR that adds or changes a skill, verify:
+
+- [ ] Frontmatter passes `skill-format-validation` (name regex, description length, no placeholders).
+- [ ] H1 matches the skill's human name; at least two required sections present.
+- [ ] `When NOT to Use` expands on any `Do NOT use` in the description.
+- [ ] Every output shape appears as a template inside SKILL.md.
+- [ ] No banned soft verbs in mandatory steps (grep: `-E "\b(should|consider|evaluate|could|may|might|try to|attempt to)\b"`).
+- [ ] `eval/RUBRIC.md` exists and the skill scores N/N under `eval/GRADER.md`.
+- [ ] Grader output is pasted into the PR description.
+- [ ] Argument-hint (if any) matches the modes the skill accepts.
+- [ ] Version bumped in frontmatter when protocol or on-disk schema changed; CHANGELOG entry written if skill is versioned.
+
+## 12. What this standard does **not** require
+
+To keep authoring costs honest:
+
+- One-shot skills with no modes, no recommendations, and no on-disk state (e.g. a pure formatter) may skip sections 4, 7, 8, and 10.
+- SCENARIOS.md is optional; RUBRIC.md and GRADER.md are not.
+- Stack addendums (iOS/Go/Web-style split inside one SKILL.md) are a pattern, not a requirement.
+
+---
+
+## Appendix: the meta-lesson
+
+The code-overhaul skill's biggest contribution is not any single rule in SKILL.md — it is the closed loop: **skill → rubric → grader → CHANGELOG → skill v+1**. Its v2.1 release notes credit the grader for every tightening. Skills that follow this standard without the loop will drift; skills that adopt the loop improve every release.
+
+Default action for PopKit skill authors: write the rubric _first_, then the SKILL.md, then run the grader before opening the PR.

--- a/packages/popkit-core/docs/skill-template/SKILL.md
+++ b/packages/popkit-core/docs/skill-template/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: skill-template
+description: >
+  Reference template for PopKit skill authoring. Not a runnable skill — lives under
+  docs/skill-template/ so it is excluded from the skill scanner. Use when starting
+  a new skill or refactoring an existing one to the standard. Do NOT copy verbatim
+  without replacing every <placeholder>.
+argument-hint: "[surgical|systematic|full] [path]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+version: 0.1.0
+---
+
+# <Skill Human Name>
+
+One-sentence statement of what the skill does and the user outcome. No hedging.
+
+## When to Use
+
+- <concrete trigger phrase, e.g. "User runs `/popkit:<command>`">
+- <secondary trigger, e.g. "Agent detects <condition>">
+- <third trigger if applicable>
+
+## When NOT to Use
+
+- <explicit non-goal 1>
+- <explicit non-goal 2>
+
+If the skill's description contains `Do NOT use for …`, this section expands the reasoning.
+
+## Modes
+
+Multi-scope skills offer modes upfront and block until the user picks one.
+
+| Mode         | Scope                  | Cap            |
+| ------------ | ---------------------- | -------------- |
+| `surgical`   | One theme, one session | ≤3 findings    |
+| `systematic` | Section-by-section     | ≤4 per section |
+| `full`       | Exhaustive, phased     | no cap         |
+
+Scope drift triggers a re-prompt; it is never silent.
+
+## Process
+
+### Step 0: Preflight
+
+Every probe has a runnable command and a fallback.
+
+| Check  | Command                   | Fallback on absent                          |
+| ------ | ------------------------- | ------------------------------------------- |
+| `git`  | `git rev-parse --git-dir` | Skip retrospective learning; note in output |
+| `bd`   | `command -v bd`           | Deferred work becomes a plain checklist     |
+| <tool> | <command>                 | <fallback>                                  |
+
+Print the preflight table before Step 1.
+
+### Step 1: Scope
+
+`AskUserQuestion` with three options (surgical / systematic / full). Block until the user answers. If a mode was passed on invocation, skip this step.
+
+### Step 2 ... N: Review sections
+
+Every section:
+
+1. Runs its checks against the repo.
+2. Emits findings using the Finding Template below.
+3. Closes with the **fixed section-close question**.
+
+### Finding Template
+
+```
+### Finding <section>.<n><letter>   [<module-tag>]
+
+Problem:    <one sentence, no hedging>
+Evidence:   <file:line> or <command>
+Options:
+  A) <action>   — effort: S|M|L, risk: S|M|L, blast: S|M|L, maintenance: S|M|L
+  B) <action>   — effort: S|M|L, risk: S|M|L, blast: S|M|L, maintenance: S|M|L
+  Defer        — effort: 0, risk: 0, blast: 0, maintenance: 0, reason: <one line>
+Recommendation: <LETTER> — <rationale tied to an engineering principle>
+```
+
+No free-form findings. The Defer option is always present with zero labels.
+
+### Section-close question (verbatim, reused every section)
+
+> Section <N>: <name> — <count> findings.
+> Approve (A) — proceed to next section.
+> Revise (B) — which finding numbers to revisit?
+> Pause (C) — write resume file and exit.
+
+One prompt per section, not one per finding.
+
+## Required outputs
+
+Publish every output as a template. Examples:
+
+### Impact/effort matrix
+
+```
+                LOW EFFORT        HIGH EFFORT
+           ┌─────────────────┬─────────────────┐
+HIGH       │ DO FIRST         │ PLAN CAREFULLY   │
+IMPACT     │ (quick wins)     │ (core overhaul)  │
+           ├─────────────────┼─────────────────┤
+LOW        │ IF TIME          │ SKIP / DEFER     │
+IMPACT     │ (polish)         │ (not worth it)   │
+           └─────────────────┴─────────────────┘
+```
+
+### Failure-mode table
+
+| codepath | failure | test? | handling? | visible? |
+| -------- | ------- | ----- | --------- | -------- |
+
+`no + no + silent` is a **critical gap**; uplift its priority one step.
+
+### Completion summary
+
+```
+╔════════════════════════════════════════════════╗
+║             <SKILL NAME> SUMMARY               ║
+╠════════════════════════════════════════════════╣
+║ Mode:              ___                         ║
+║ Status:            complete | paused           ║
+║ Findings approved: ___                         ║
+║ Findings deferred: ___                         ║
+║ Critical gaps:     ___                         ║
+║ Resume file:       <path> | —                  ║
+╚════════════════════════════════════════════════╝
+```
+
+## Checkpoint / resume (for multi-section skills)
+
+After each section-close resolves (Approve or Pause, not Revise), write `.<skill-name>/resume.md`:
+
+```yaml
+version: 0.1.0
+mode: surgical | systematic | full
+target: <absolute path>
+written_at: <ISO-8601>
+completed_sections: [1, 2]
+next_section: 3
+findings:
+  - id: 2.1A
+    tag: <module-tag>
+    title: <one line>
+    chosen: A | B | Defer
+```
+
+Resume files older than 7 days trigger a fresh-vs-resume prompt.
+
+## Integration Points
+
+| Component             | Purpose        |
+| --------------------- | -------------- |
+| `<path/to/helper.py>` | <what it does> |
+| `<other integration>` | <purpose>      |
+
+## Anti-patterns
+
+- Free-form findings — every finding uses the template.
+- Per-item `AskUserQuestion` — batch at section close instead.
+- Soft verbs in mandatory steps — replace with directives.
+- Silent scope reduction — re-issue the mode question.
+- Stale diagrams — update or delete.

--- a/packages/popkit-core/docs/skill-template/eval/GRADER.md
+++ b/packages/popkit-core/docs/skill-template/eval/GRADER.md
@@ -1,0 +1,45 @@
+# Grader Prompt Template
+
+You are an independent grader. You have not seen the development history of this skill. Your job: score the skill's `SKILL.md` against the sibling `RUBRIC.md`.
+
+## Procedure
+
+1. Read the full `eval/RUBRIC.md`.
+2. Read the full `SKILL.md`.
+3. Identify which criteria apply to this skill. Skip criteria the rubric explicitly marks as optional for the skill's shape (one-shot skills skip C6–C9; non-refactor skills skip C8; non-repo-scanning skills skip C10).
+4. For each applicable criterion:
+   - Quote the specific lines in `SKILL.md` that justify PASS (or the absence, for FAIL).
+   - Score 0 or 1. No half credit.
+   - If a criterion requires `all of A, B, C`, every sub-item must be present to earn the point.
+5. Sum the scores.
+6. Report in this exact format:
+
+```
+# Grade: <N>/<applicable>
+
+## C1. Frontmatter conformance — <PASS|FAIL>
+<one-sentence justification citing SKILL.md:line or a quoted snippet>
+
+## C2. Required sections present — <PASS|FAIL>
+...
+
+...through every applicable criterion...
+
+## Skipped criteria
+- C<N>: <reason>, e.g. "skill is one-shot, no modes"
+
+## Gaps to fix
+- For each failing criterion: quote the exact text that would earn the point if added.
+```
+
+## Rules
+
+- Be strict. A gesture toward a criterion is not enough — the text must enforce it.
+- Soft verbs (`should`, `consider`, `evaluate`, `could`, `may`, `might`) in mandatory steps fail C3. Soft verbs in glossaries or illustrative examples are fine.
+- Cite line numbers when quoting (`SKILL.md:NNN`).
+- Do not grade generously because earlier versions passed. Grade the current text as-is.
+- Do not rewrite the skill. Only grade.
+
+## Running against a changed skill
+
+Every PR that touches `SKILL.md` runs this grader and pastes the output into the PR description. A PR that drops the score below the previous release does not merge without a note in the skill's `CHANGELOG.md` (or PR description if the skill is unversioned) explaining the regression.

--- a/packages/popkit-core/docs/skill-template/eval/RUBRIC.md
+++ b/packages/popkit-core/docs/skill-template/eval/RUBRIC.md
@@ -1,0 +1,116 @@
+# Skill Rubric Template
+
+Binary, 1 point each. Target: N/N. **Partial matches score 0.**
+
+Copy this file into a new skill's `eval/RUBRIC.md` and delete criteria that do not apply (e.g., C7–C9 for one-shot skills with no modes or checkpointing). Replace `<skill-name>` and `<skill-path>` throughout.
+
+Every criterion is checkable against `<skill-path>/SKILL.md` alone. A grader with no other context can score the skill.
+
+---
+
+## C1. Frontmatter conformance
+
+Pass if **all** of:
+
+- `name` matches `^[a-z0-9-]+$` and matches the skill directory name.
+- `description` opens with a directive verb, contains a "Use when …" trigger phrase, and names at least one non-goal ("Do NOT use for …").
+- `description` length is between 20 and 300 characters (≤200 preferred).
+- `allowed-tools` names every shell/file tool the skill actually calls (Read, Grep, Glob, Bash).
+- No placeholder strings (`TODO`, `TBD`, `placeholder`) appear in frontmatter.
+
+## C2. Required sections present
+
+Pass if **all** of:
+
+- H1 matches the skill's human name.
+- At least two of `When to Use`, `When NOT to Use`, `Process`, `Integration Points` appear as H2s.
+- If `description` contains "Do NOT use", `When NOT to Use` expands the reasoning in at least two bullets.
+
+## C3. No soft verbs in mandatory steps
+
+Pass if:
+
+- Running `grep -nE '\b(should|consider|evaluate|could|may|might|try to|attempt to)\b' SKILL.md` against mandatory steps (Process, Protocol, Required outputs, Hard gates) returns zero matches.
+
+Soft verbs are permitted in descriptive glossaries and illustrative examples.
+
+## C4. Output schemas are published inline
+
+Pass if **all** of:
+
+- Every user-visible artifact the skill emits (report, finding, plan, summary) appears as a template with named slots inside SKILL.md.
+- No "…" or "etc." appears inside any template.
+- Optional fields are labeled `Optional:` explicitly.
+
+## C5. Finding / recommendation template (for recommendation-making skills)
+
+Pass if **all** of:
+
+- A `Finding Template` block appears with: three-part ID (`<section>.<n><letter>`), problem statement, evidence (path:line or runnable command), 2–3 options with S/M/L labels for effort/risk/blast/maintenance.
+- A `Defer` option carries zero labels (`effort: 0, risk: 0, blast: 0, maintenance: 0`) and a one-line reason field.
+- A `Recommendation` letter with a rationale tied to an engineering principle.
+- The template is referenced from every review section, or defined before sections with "mandatory for all sections" stated.
+- "No free-form findings" or equivalent exclusion is stated.
+
+Skip this criterion for skills that do not emit findings.
+
+## C6. Batched section-close question
+
+Pass if **all** of:
+
+- A single fixed section-close question is defined verbatim and reused every section.
+- Three branches (Approve / Revise / Pause) are enumerated with their consequences.
+- "One prompt per section, not per finding" or equivalent is stated.
+
+Skip this criterion for one-shot skills.
+
+## C7. Mode commitment (for multi-scope skills)
+
+Pass if **all** of:
+
+- Modes are named explicitly: `surgical`, `systematic`, `full` (or a documented equivalent set).
+- Numeric caps per mode are stated (e.g., SURGICAL ≤3, SYSTEMATIC ≤4, FULL no cap).
+- Step 1 calls `AskUserQuestion` and blocks until the user answers; mode passed on invocation skips Step 1.
+- A scope-drift rule is documented: mid-run expansion requires re-issuing the mode question.
+
+Skip this criterion for one-shot skills.
+
+## C8. Hard gates (for audit / refactor skills)
+
+Pass if **all** of:
+
+- Characterization-tests-first: stated verbatim as a hard rule.
+- Failure-mode table is a required non-skippable output with the `codepath | failure | test? | handling? | visible?` columns.
+- `no-test + no-handling + silent → critical gap` rule is stated with the priority-uplift consequence.
+
+Skip this criterion for non-refactor skills.
+
+## C9. Checkpoint / resume (for multi-section skills)
+
+Pass if **all** of:
+
+- Checkpoint file path is named: `.<skill-name>/resume.md` or the equivalent.
+- Resume schema lists at minimum `version`, `mode`, `target`, `written_at`, `completed_sections`, `next_section`, `findings`.
+- Write-timing is specified: after each section-close resolves Approve or Pause (not Revise).
+- Stale-file rule is documented (7-day threshold or explicit alternative).
+
+Skip this criterion for skills that complete in a single section.
+
+## C10. Degenerate / edge-case handling (for audit / generator skills)
+
+Pass if **all** of:
+
+- "No tests detected" path is specified (section becomes a test-creation plan; refactor-of-untested-code is blocked behind characterization tests).
+- "No git history" path is specified (retrospective-learning step is skipped with a printed note).
+- "No dependency manifest" path is specified (dependency section output is a single stated line).
+- "Single-file or near-empty repo" path refuses the large modes with a stated reason.
+
+Skip this criterion for skills that do not scan repos.
+
+---
+
+## Scoring
+
+Total = sum of criteria applicable to the skill. Pass = N/N. Any failing criterion is a gap to fix before the PR lands.
+
+A skill that uses "should" where the rubric requires a directive fails the relevant criterion. A skill that gestures toward a requirement without enforcing it fails.

--- a/packages/popkit-core/skills/pop-bug-reporter/SKILL.md
+++ b/packages/popkit-core/skills/pop-bug-reporter/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: bug-reporter
-description: "Capture bug context and generate structured reports, optionally filing GitHub issues or sharing anonymized patterns. Use when the user reports a bug with /popkit:bug or an agent is repeatedly stuck. Do NOT use for feature requests, routine code errors the agent can fix in place, or asking questions about expected behavior."
+name: pop-bug-reporter
+description: "Capture bug context into structured reports. Use when /popkit:bug reports a bug or an agent repeatedly gets stuck. Do NOT use for feature requests, fixable code errors, or expected-behavior questions."
 ---
 
 # Bug Reporter
@@ -86,19 +86,19 @@ Context:
 
 Recent Actions:
   <n>. <tool>: <target> (<status>)
-  ... up to 10 most recent tool calls
+  Repeat for up to 10 most recent tool calls
 
 Errors Detected:
   [<ErrorType>] <message>
-  ... one line per distinct error
+  Repeat once per distinct error, or write "none"
 
 Stuck Patterns:
   - <pattern>: <evidence>
-  ... one line per detected pattern, empty list permitted
+  Repeat once per detected pattern, or write "none"
 
 Suggested Actions:
   - <imperative verb> <object>
-  ... 1–3 actions, imperative mood only
+  Provide 1-3 actions, imperative mood only
 
 Optional: Reproduction Steps
   1. <step>

--- a/packages/popkit-core/skills/pop-bug-reporter/SKILL.md
+++ b/packages/popkit-core/skills/pop-bug-reporter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bug-reporter
-description: Capture bug context, generate reports, and optionally create GitHub issues or share patterns
+description: "Capture bug context and generate structured reports, optionally filing GitHub issues or sharing anonymized patterns. Use when the user reports a bug with /popkit:bug or an agent is repeatedly stuck. Do NOT use for feature requests, routine code errors the agent can fix in place, or asking questions about expected behavior."
 ---
 
 # Bug Reporter
@@ -13,6 +13,13 @@ Capture and report bugs with automatic context gathering, local logging, GitHub 
 - Agent encounters repeated errors or gets stuck
 - Need to document an issue for later investigation
 - Want to share a bug pattern with the collective
+
+## When NOT to Use
+
+- **Feature requests** — use the feature-development skill, not this one.
+- **Routine code errors the agent can fix in place** — fix and continue; a bug report is overhead when the failure is understood and resolvable in the same session.
+- **Questions about expected behavior** — answer the question instead of filing a bug.
+- **Security vulnerabilities** — route to `SECURITY.md` disclosure, not the public bug log.
 
 ## Input
 
@@ -60,38 +67,81 @@ Context includes:
 
 ### 3. Generate Report
 
-Format the bug report:
+Bug reports follow a fixed schema. Every named slot is required unless labeled `Optional:`. No free-form fields.
+
+**Schema:**
 
 ```
 Bug Report
 ==========
-ID: bug-2024-12-04-abc123
-Time: 2024-12-04T10:30:00Z
+ID:          bug-<YYYY-MM-DD>-<slug>
+Time:        <ISO-8601>
+Description: <one-sentence user statement; no hedging>
 
+Context:
+  Language:    <detected>
+  Framework:   <detected | none>
+  Branch:      <git branch>
+  Uncommitted: <N files>
+
+Recent Actions:
+  <n>. <tool>: <target> (<status>)
+  ... up to 10 most recent tool calls
+
+Errors Detected:
+  [<ErrorType>] <message>
+  ... one line per distinct error
+
+Stuck Patterns:
+  - <pattern>: <evidence>
+  ... one line per detected pattern, empty list permitted
+
+Suggested Actions:
+  - <imperative verb> <object>
+  ... 1–3 actions, imperative mood only
+
+Optional: Reproduction Steps
+  1. <step>
+  2. <step>
+```
+
+**Example (filled):**
+
+```
+Bug Report
+==========
+ID:          bug-2024-12-04-abc123
+Time:        2024-12-04T10:30:00Z
 Description: Agent got stuck on OAuth flow
 
 Context:
-  Language: TypeScript
-  Framework: Next.js
-  Branch: feature/oauth
+  Language:    TypeScript
+  Framework:   Next.js
+  Branch:      feature/oauth
   Uncommitted: 3 files
 
 Recent Actions:
-  1. Edit src/auth/oauth.ts
-  2. Bash: npm run build (failed)
-  3. Edit src/auth/oauth.ts (same file, 2nd time)
+  1. Edit:  src/auth/oauth.ts (ok)
+  2. Bash:  npm run build (failed)
+  3. Edit:  src/auth/oauth.ts (ok, 2nd edit to same file)
 
 Errors Detected:
   [TypeError] Cannot read property 'token' of undefined
 
 Stuck Patterns:
   - Same file edited 3 times: oauth.ts
-  - Build command failed
+  - Build command failed twice
 
 Suggested Actions:
-  - Consider stepping back and reviewing the approach
-  - Check for null/undefined values
+  - Revert the last two edits to oauth.ts and re-read the module.
+  - Check the refresh-token path for null before property access.
 ```
+
+Suggested-action rules:
+
+- Imperative verbs only (`Revert`, `Check`, `Add`, `Remove`). No `consider`, `try`, `may`, `should`.
+- Each action names a concrete object (a file, function, or test) — not "the approach."
+- Maximum three actions. Rank by estimated unblock time, shortest first.
 
 ### 4. Output Actions
 

--- a/packages/popkit-core/skills/pop-bug-reporter/eval/GRADER.md
+++ b/packages/popkit-core/skills/pop-bug-reporter/eval/GRADER.md
@@ -1,0 +1,58 @@
+# pop-bug-reporter Grader
+
+You are an independent grader. You have not seen the development history of this
+skill. Your job is to score `packages/popkit-core/skills/pop-bug-reporter/SKILL.md`
+against `packages/popkit-core/skills/pop-bug-reporter/eval/RUBRIC.md`.
+
+## Inputs
+
+- Skill under test: `packages/popkit-core/skills/pop-bug-reporter/SKILL.md`
+- Rubric: `packages/popkit-core/skills/pop-bug-reporter/eval/RUBRIC.md`
+
+## Procedure
+
+1. Read the full rubric.
+2. Read the full skill.
+3. Score each criterion C1-C7 as `PASS` or `FAIL`.
+4. Award 1 point only when every sub-item in the criterion is satisfied.
+5. Award 0 points for partial matches, implied behavior, or text that gestures at
+   the rule without enforcing it.
+6. Cite `SKILL.md:<line>` for every pass and fail.
+7. Report gaps as exact text the skill could add or change to earn the point.
+
+## Output Format
+
+```
+# Grade: <N>/7
+
+## C1. Frontmatter conformance - <PASS|FAIL>
+<one-sentence justification citing SKILL.md:<line>>
+
+## C2. Required sections present - <PASS|FAIL>
+<one-sentence justification citing SKILL.md:<line>>
+
+## C3. No soft verbs in mandatory steps - <PASS|FAIL>
+<one-sentence justification citing SKILL.md:<line> or the grep result>
+
+## C4. Bug Report schema is rigid - <PASS|FAIL>
+<one-sentence justification citing SKILL.md:<line>>
+
+## C5. Suggested-action discipline - <PASS|FAIL>
+<one-sentence justification citing SKILL.md:<line>>
+
+## C6. Flag and subcommand contract - <PASS|FAIL>
+<one-sentence justification citing SKILL.md:<line>>
+
+## C7. Integration points are enumerated - <PASS|FAIL>
+<one-sentence justification citing SKILL.md:<line>>
+
+## Gaps to fix
+- <criterion>: <exact text to add or change, or "None">
+```
+
+## Rules
+
+- Be strict. A near match is a fail.
+- Do not rewrite the skill beyond the "Gaps to fix" section.
+- Do not give credit for intent that is not visible in `SKILL.md`.
+- Soft verbs listed in C3 are allowed only on the line that bans those words.

--- a/packages/popkit-core/skills/pop-bug-reporter/eval/RUBRIC.md
+++ b/packages/popkit-core/skills/pop-bug-reporter/eval/RUBRIC.md
@@ -1,4 +1,4 @@
-# bug-reporter SKILL.md rubric
+# pop-bug-reporter SKILL.md rubric
 
 7 criteria, 1 point each. Target: 7/7. Partial matches score 0.
 
@@ -10,7 +10,7 @@ This skill is capture-shaped (not audit-shaped), so rubric criteria C5–C10 fro
 
 Pass if **all** of:
 
-- `name` is `bug-reporter`, matches the directory name, and matches `^[a-z0-9-]+$`.
+- `name` is `pop-bug-reporter`, matches the directory name, and matches `^[a-z0-9-]+$`.
 - `description` opens with a directive verb.
 - `description` contains a "Use when …" trigger phrase.
 - `description` contains "Do NOT use for …" with at least one explicit non-goal.
@@ -72,4 +72,4 @@ Pass if:
 
 Total = sum of criteria. Pass = 7/7. Any failing criterion is a gap to fix before the PR lands.
 
-The grader in `eval/GRADER.md` (the template at `packages/popkit-core/docs/skill-template/eval/GRADER.md`) runs against this rubric. Paste the grader output into any PR that modifies `SKILL.md`.
+The sibling grader in `eval/GRADER.md` runs against this rubric. Paste the grader output into any PR that modifies `SKILL.md`.

--- a/packages/popkit-core/skills/pop-bug-reporter/eval/RUBRIC.md
+++ b/packages/popkit-core/skills/pop-bug-reporter/eval/RUBRIC.md
@@ -1,0 +1,75 @@
+# bug-reporter SKILL.md rubric
+
+7 criteria, 1 point each. Target: 7/7. Partial matches score 0.
+
+This skill is capture-shaped (not audit-shaped), so rubric criteria C5–C10 from the PopKit skill-authoring template are not applicable. See `packages/popkit-core/docs/skill-template/eval/RUBRIC.md` for the full template.
+
+---
+
+## C1. Frontmatter conformance
+
+Pass if **all** of:
+
+- `name` is `bug-reporter`, matches the directory name, and matches `^[a-z0-9-]+$`.
+- `description` opens with a directive verb.
+- `description` contains a "Use when …" trigger phrase.
+- `description` contains "Do NOT use for …" with at least one explicit non-goal.
+- `description` length is between 20 and 300 characters.
+- No placeholder strings (`TODO`, `TBD`, `placeholder`) appear in frontmatter.
+
+## C2. Required sections present
+
+Pass if **all** of:
+
+- H1 is `Bug Reporter`.
+- `## When to Use` is present with at least three bullets.
+- `## When NOT to Use` is present with at least three bullets and expands the "Do NOT use" cases from the description.
+- `## Process` (or its numbered step sections `### 1. Parse Request`, `### 2. Capture Context`, etc.) is present.
+- `## Integration Points` is present.
+
+## C3. No soft verbs in mandatory steps
+
+Pass if:
+
+- Running `grep -nE '\b(should|consider|evaluate|could|may |might|try to|attempt to)\b'` against the Process steps, Schema, and Suggested-action rules returns zero matches — excluding the one line that enumerates banned words as a rule statement.
+
+## C4. Bug Report schema is rigid
+
+Pass if **all** of:
+
+- A `Schema:` block appears under `### 3. Generate Report` with named slots (ID, Time, Description, Context, Recent Actions, Errors Detected, Stuck Patterns, Suggested Actions).
+- Every required slot is labeled; optional slots are labeled `Optional:` explicitly.
+- "No free-form fields" or equivalent exclusion is stated.
+- A filled `Example:` follows the schema and matches the schema's slots exactly.
+
+## C5. Suggested-action discipline
+
+Pass if **all** of:
+
+- Imperative-verb rule is stated (no `consider`, `try`, `may`, `should`).
+- Each action must name a concrete object (file, function, or test) — stated verbatim.
+- Maximum-action cap is numeric (3).
+- Ranking rule is stated (shortest unblock time first).
+
+## C6. Flag and subcommand contract
+
+Pass if **all** of:
+
+- Every flag (`--issue`, `--share`, `--verbose`, `--no-context`) is documented in the `## Input` section.
+- Every subcommand (`list`, `view <id>`, `clear`) has a handler in `## Subcommand Handlers`.
+- GitHub label validation path is documented under `--issue` (C1 #96 reference).
+- The anonymization rule set is documented under `--share`.
+
+## C7. Integration points are enumerated
+
+Pass if:
+
+- `## Integration Points` contains a table with at least four rows, each row naming a component path and its purpose.
+
+---
+
+## Scoring
+
+Total = sum of criteria. Pass = 7/7. Any failing criterion is a gap to fix before the PR lands.
+
+The grader in `eval/GRADER.md` (the template at `packages/popkit-core/docs/skill-template/eval/GRADER.md`) runs against this rubric. Paste the grader output into any PR that modifies `SKILL.md`.


### PR DESCRIPTION
Codify a house style for PopKit skills modeled on ehmo/code-overhaul-skill:rigid output schemas, numeric mode caps, batched section-close confirmation,soft-verb ban in mandatory steps, and a binary eval rubric shipped alongsideevery recommendation-making skill.- packages/popkit-core/docs/SKILL_AUTHORING.md: the standard.- packages/popkit-core/docs/skill-template/: reference SKILL.md plus  eval/RUBRIC.md and eval/GRADER.md templates. Lives under docs/ so the  skill scanner ignores it.- packages/popkit-core/skills/pop-bug-reporter: light refactor as the first  adopter — tightens the frontmatter description to include trigger phrases  and a Do-NOT-use clause, adds a When-NOT-to-Use section, replaces the  free-form bug-report template with a named-slot schema + filled example,  adds suggested-action discipline (imperative mood, concrete object, max 3),  and scrubs the one soft verb ("Consider stepping back ...").- packages/popkit-core/skills/pop-bug-reporter/eval/RUBRIC.md: 7 binary  criteria specific to this capture-shaped skill.The meta-lesson from the code-overhaul skill is the closed loop(skill -> rubric -> grader -> CHANGELOG -> skill v+1), not any single rule.The standard makes the rubric+grader step mandatory for future skills.https://claude.ai/code/session_01EhYpu4fxhrBWuTDUu58YBM

---

## Grader output (2026-04-24)

# Grade: 7/7

## C1. Frontmatter conformance - PASS
`SKILL.md:2` sets `name: pop-bug-reporter`, matching the skill directory, and `SKILL.md:3` starts with "Capture", includes "Use when", includes "Do NOT use for", and is 200 characters.

## C2. Required sections present - PASS
`SKILL.md:6`, `SKILL.md:10`, `SKILL.md:17`, `SKILL.md:32`, and `SKILL.md:307` provide the H1, use/non-use guidance, process, and integration table.

## C3. No soft verbs in mandatory steps - PASS
The only soft-verb grep hit is `SKILL.md:142`, which is the explicit banned-word rule line allowed by the rubric.

## C4. Bug Report schema is rigid - PASS
`SKILL.md:68-106` publishes a named-slot schema with required fields, explicit optional reproduction steps, and no schema ellipses.

## C5. Suggested-action discipline - PASS
`SKILL.md:140-144` requires imperative verbs, concrete objects, a maximum of three actions, and shortest-unblock-time ranking.

## C6. Flag and subcommand contract - PASS
`SKILL.md:28-30`, `SKILL.md:157-185`, `SKILL.md:187-192`, `SKILL.md:202-224`, and `SKILL.md:226-249` document flags, subcommands, GitHub label validation, and anonymization.

## C7. Integration points are enumerated - PASS
`SKILL.md:307-314` contains a table with four component paths and purposes.

## Gaps to fix
- None.

## Pressure test

- `npm ci` passed from the committed lockfile.
- `npm run docs:build` passed and built 27 pages.
- `npm audit --json` reported 0 vulnerabilities on this branch.
- `npm run lint:ts` passed.
- `npm run lint:py` passed.
- `git diff --check` passed.
- Targeted skill check passed: name matches directory, description length is 200, grader exists, rubric points to the grader, and the bug-report schema contains no ellipses.

Note: I did not add `@astrojs/check`. The current checker line adds a vulnerable language-server/YAML chain; the older clean checker does not actually run diagnostics under Astro 6. For this PR, docs CI is kept as a real static build and Astro is bumped to 6.1.9 to clear the existing Astro advisory.