### PR TITLE
feat(power-mode): add execution spine contract

### DIFF
--- a/packages/docs/src/content/docs/concepts/execution-spine.md
+++ b/packages/docs/src/content/docs/concepts/execution-spine.md
@@ -1,0 +1,94 @@
+---
+title: Execution Spine
+description: A small PopKit contract for connecting context, sandboxed execution, and evaluation
+---
+
+# Execution Spine
+
+PopKit should treat execution as a spine, not as another pile of commands:
+
+```text
+Context -> Sandbox or worktree execution -> Verification and eval -> Handoff
+```
+
+The useful lesson from Sandcastle, Evalite, and Matt Pocock's skills is not
+"install another repo." It is that the strongest systems keep a small,
+inspectable artifact at the center of the workflow.
+
+## What We Learn
+
+| Source                                                 | Useful pattern                                                                 | PopKit application                                                                                        |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| [Sandcastle](https://github.com/mattpocock/sandcastle) | Objective-driven execution that produces logs, commits, and reviewable output. | Keep a canonical lane result that records objective, backend, branch, artifacts, checks, and next action. |
+| [Evalite](https://github.com/mattpocock/evalite)       | Evals are part of development, not an afterthought.                            | Score skill and lane outputs before adding a runtime eval dependency.                                     |
+| [skills](https://github.com/mattpocock/skills)         | Small focused skills with explicit scope and reusable methodology.             | Keep PopKit skills protocol-shaped; avoid broad magic commands with unclear output.                       |
+| PopKit skill authoring standards                       | Rubrics and graders make recommendations testable.                             | Reuse rubric/grader thinking for execution results and sandbox choices.                                   |
+
+## Current Overlap
+
+PopKit already has meaningful pieces:
+
+- Worktree commands for local branch isolation.
+- Power Mode protocols for multi-agent objectives and coordination.
+- `pop-sandbox` for E2B-backed sandbox operations.
+- Skill authoring guidance that expects rubrics, graders, and explicit output contracts.
+
+The gap is not another sandbox provider. The gap is one result artifact that
+connects these pieces after each lane runs.
+
+## Contract
+
+The execution spine starts with `ExecutionLaneResult`:
+
+- `objective`: the user-facing job the lane attempted.
+- `sandboxBackend`: `none`, `local-worktree`, `e2b`, `vercel-sandbox`, or `cloudflare-sandbox`.
+- `status`: `planned`, `running`, `succeeded`, `failed`, `blocked`, or `canceled`.
+- `branch`, `worktreePath`, `logPath`, and `providerRunId`: traceability.
+- `commits` and `artifacts`: reviewable outputs.
+- `validation`: tests, evals, reviews, and smoke checks.
+- `summary` and `nextAction`: handoff-ready decision text.
+
+That contract is implemented in
+`packages/popkit-core/power-mode/execution_spine.py` and mirrored by
+`packages/popkit-core/output-styles/schemas/execution-lane-result.schema.json`.
+
+## Provider Posture
+
+| Backend              | Use now? | Why                                                                 |
+| -------------------- | -------- | ------------------------------------------------------------------- |
+| `local-worktree`     | Yes      | Highest-control default for PopKit development and repo-local work. |
+| `e2b`                | Yes      | Already present through `pop-sandbox`; keep it provider-contained.  |
+| `vercel-sandbox`     | Watch    | Relevant if Vercel remains the production/deploy center.            |
+| `cloudflare-sandbox` | Watch    | Relevant if ElShaddai shifts more execution to Cloudflare.          |
+| `none`               | Yes      | Useful for research, planning, docs-only work, and blocked lanes.   |
+
+Do not add a provider dependency until the result contract is being emitted
+from real PopKit flows. Provider choice should be an adapter decision, not a
+workflow rewrite.
+
+## Adversarial Review
+
+| Risk                                           | Objection                                                                 | Response                                                                                         |
+| ---------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| This could become PopKit bloat.                | A new contract can become another artifact nobody reads.                  | Keep it one dataclass, one schema, and one score gate. Delete it if workflows do not emit it.    |
+| Provider enums can pretend integrations exist. | Listing Vercel and Cloudflare could imply supported adapters prematurely. | The enum records candidate backends only; no package or runtime dependency is added here.        |
+| A local score is not a real eval suite.        | `score_execution_lane_result` is weaker than Evalite-style examples.      | Correct. It is a pre-Evalite quality gate so PopKit can measure output shape before model evals. |
+| Sandcastle may be simpler than PopKit.         | Sandcastle's narrow scope can deliver more bang for the buck.             | PopKit should copy the narrow execution artifact, not the whole product boundary.                |
+
+## Priority
+
+| Priority | Keep / Try / Avoid | Decision                                                                              |
+| -------- | ------------------ | ------------------------------------------------------------------------------------- |
+| P0       | Keep               | Use `ExecutionLaneResult` as the shared handoff artifact for execution lanes.         |
+| P0       | Keep               | Keep local worktrees as the default PopKit sandbox for repo work.                     |
+| P1       | Try                | Emit execution results from Power Mode and plan execution flows.                      |
+| P1       | Try                | Add Evalite-style examples after PopKit has real result fixtures.                     |
+| P2       | Watch              | Spike Vercel and Cloudflare sandbox adapters only after local/E2B flows emit results. |
+| P3       | Avoid              | Rewriting PopKit around Sandcastle, Evalite, or any single hosted sandbox provider.   |
+
+## Next Implementation Step
+
+Wire the contract into the lane coordinator or plan executor so every lane
+finishes with one `ExecutionLaneResult`. That gives PopKit the Sandcastle-style
+trace, the Evalite-style measurement surface, and the small-skill discipline
+without bloating the runtime.

--- a/packages/popkit-core/output-styles/schemas/README.md
+++ b/packages/popkit-core/output-styles/schemas/README.md
@@ -48,6 +48,7 @@ All schemas follow JSON Schema Draft-07 format:
 | `debugging-report.schema.json`           | debugging-report           | bug-whisperer                 |
 | `deployment-report.schema.json`          | deployment-report          | deployment-validator          |
 | `documentation-report.schema.json`       | documentation-report       | documentation-maintainer      |
+| `execution-lane-result.schema.json`      | execution-lane-result      | power-coordinator             |
 | `migration-report.schema.json`           | migration-report           | migration-specialist          |
 | `performance-report.schema.json`         | performance-report         | performance-optimizer         |
 | `power-mode-checkin.schema.json`         | power-mode-checkin         | power-coordinator             |

--- a/packages/popkit-core/output-styles/schemas/execution-lane-result.schema.json
+++ b/packages/popkit-core/output-styles/schemas/execution-lane-result.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Execution Lane Result Schema",
+  "description": "Canonical result emitted by one PopKit execution lane after sandboxed or worktree-based work.",
+  "type": "object",
+  "required": ["objective", "status", "sandboxBackend", "summary", "nextAction", "validation"],
+  "additionalProperties": false,
+  "properties": {
+    "objective": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The user-facing objective the lane attempted."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["planned", "running", "succeeded", "failed", "blocked", "canceled"],
+      "description": "Lifecycle status of the lane."
+    },
+    "sandboxBackend": {
+      "type": "string",
+      "enum": ["none", "local-worktree", "e2b", "vercel-sandbox", "cloudflare-sandbox"],
+      "description": "Execution provider used by the lane."
+    },
+    "branch": {
+      "type": "string",
+      "description": "Git branch used by the lane, when applicable."
+    },
+    "worktreePath": {
+      "type": "string",
+      "description": "Local worktree path used by the lane, when applicable."
+    },
+    "logPath": {
+      "type": "string",
+      "description": "Path to captured lane logs."
+    },
+    "providerRunId": {
+      "type": "string",
+      "description": "External provider run ID, when a hosted sandbox is used."
+    },
+    "commits": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Commit SHAs produced by the lane."
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["kind", "path"],
+        "additionalProperties": false,
+        "properties": {
+          "kind": {
+            "type": "string",
+            "description": "Artifact type, such as diff, doc, log, screenshot, or eval."
+          },
+          "path": {
+            "type": "string",
+            "description": "Path or URL for the artifact."
+          },
+          "description": {
+            "type": "string",
+            "description": "Short explanation of the artifact."
+          }
+        }
+      },
+      "description": "Artifacts produced by the lane."
+    },
+    "validation": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "status"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the test, eval, review, or smoke check."
+          },
+          "status": {
+            "type": "string",
+            "enum": ["not-run", "passed", "failed", "skipped"],
+            "description": "Validation status."
+          },
+          "command": {
+            "type": "string",
+            "description": "Command or check that was run."
+          },
+          "summary": {
+            "type": "string",
+            "description": "Validation summary."
+          }
+        }
+      },
+      "description": "Checks used to verify the lane output."
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Concise summary of what happened."
+    },
+    "nextAction": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Recommended next action for the coordinator or user."
+    },
+    "startedAt": {
+      "type": "string",
+      "description": "ISO-8601 timestamp for when lane execution started."
+    },
+    "completedAt": {
+      "type": "string",
+      "description": "ISO-8601 timestamp for when lane execution completed."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Provider-specific extension data."
+    }
+  }
+}

--- a/packages/popkit-core/power-mode/execution_spine.py
+++ b/packages/popkit-core/power-mode/execution_spine.py
@@ -81,6 +81,10 @@ class ValidationCheck:
         }
 
 
+def _utc_timestamp() -> str:
+    return datetime.now(UTC).isoformat()
+
+
 @dataclass
 class ExecutionLaneResult:
     """Canonical result emitted by one PopKit execution lane."""
@@ -97,7 +101,7 @@ class ExecutionLaneResult:
     commits: List[str] = field(default_factory=list)
     artifacts: List[Union[ExecutionArtifact, Dict[str, str]]] = field(default_factory=list)
     validation: List[Union[ValidationCheck, Dict[str, str]]] = field(default_factory=list)
-    started_at: str = field(default_factory=lambda: _utc_timestamp())
+    started_at: str = field(default_factory=_utc_timestamp)
     completed_at: Optional[str] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
 
@@ -138,10 +142,6 @@ class ExecutionLaneResult:
         }
         data.update({key: value for key, value in optional_fields.items() if value})
         return data
-
-
-def _utc_timestamp() -> str:
-    return datetime.now(UTC).isoformat()
 
 
 def create_execution_lane_result(

--- a/packages/popkit-core/power-mode/execution_spine.py
+++ b/packages/popkit-core/power-mode/execution_spine.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+Execution lane result contract for PopKit's context -> sandbox -> eval spine.
+
+This intentionally avoids binding PopKit to a specific sandbox or eval provider.
+The contract gives Power Mode, worktree flows, and future sandbox adapters one
+small artifact shape to emit after a lane runs.
+"""
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+
+
+class ExecutionStatus(str, Enum):
+    """Lifecycle status for an execution lane."""
+
+    PLANNED = "planned"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    BLOCKED = "blocked"
+    CANCELED = "canceled"
+
+
+class SandboxBackend(str, Enum):
+    """Sandbox/provider target used by an execution lane."""
+
+    NONE = "none"
+    LOCAL_WORKTREE = "local-worktree"
+    E2B = "e2b"
+    VERCEL_SANDBOX = "vercel-sandbox"
+    CLOUDFLARE_SANDBOX = "cloudflare-sandbox"
+
+
+class ValidationStatus(str, Enum):
+    """Validation result for a command, eval, or reviewer check."""
+
+    NOT_RUN = "not-run"
+    PASSED = "passed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+@dataclass
+class ExecutionArtifact:
+    """File, URL, log, diff, or other artifact created by a lane."""
+
+    kind: str
+    path: str
+    description: str = ""
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "kind": self.kind,
+            "path": self.path,
+            "description": self.description,
+        }
+
+
+@dataclass
+class ValidationCheck:
+    """A test, eval, review, or smoke check attached to an execution lane."""
+
+    name: str
+    status: Union[ValidationStatus, str]
+    command: str = ""
+    summary: str = ""
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.status, ValidationStatus):
+            self.status = ValidationStatus(self.status)
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "name": self.name,
+            "status": self.status.value,
+            "command": self.command,
+            "summary": self.summary,
+        }
+
+
+@dataclass
+class ExecutionLaneResult:
+    """Canonical result emitted by one PopKit execution lane."""
+
+    objective: str
+    status: Union[ExecutionStatus, str]
+    sandbox_backend: Union[SandboxBackend, str]
+    summary: str
+    next_action: str
+    branch: Optional[str] = None
+    worktree_path: Optional[str] = None
+    log_path: Optional[str] = None
+    provider_run_id: Optional[str] = None
+    commits: List[str] = field(default_factory=list)
+    artifacts: List[Union[ExecutionArtifact, Dict[str, str]]] = field(default_factory=list)
+    validation: List[Union[ValidationCheck, Dict[str, str]]] = field(default_factory=list)
+    started_at: str = field(default_factory=lambda: _utc_timestamp())
+    completed_at: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.status, ExecutionStatus):
+            self.status = ExecutionStatus(self.status)
+        if not isinstance(self.sandbox_backend, SandboxBackend):
+            self.sandbox_backend = SandboxBackend(self.sandbox_backend)
+        self.artifacts = [
+            artifact if isinstance(artifact, ExecutionArtifact) else ExecutionArtifact(**artifact)
+            for artifact in self.artifacts
+        ]
+        self.validation = [
+            check if isinstance(check, ValidationCheck) else ValidationCheck(**check)
+            for check in self.validation
+        ]
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "objective": self.objective,
+            "status": self.status.value,
+            "sandboxBackend": self.sandbox_backend.value,
+            "summary": self.summary,
+            "nextAction": self.next_action,
+            "commits": list(self.commits),
+            "artifacts": [artifact.to_dict() for artifact in self.artifacts],
+            "validation": [check.to_dict() for check in self.validation],
+            "startedAt": self.started_at,
+            "metadata": dict(self.metadata),
+        }
+
+        optional_fields = {
+            "branch": self.branch,
+            "worktreePath": self.worktree_path,
+            "logPath": self.log_path,
+            "providerRunId": self.provider_run_id,
+            "completedAt": self.completed_at,
+        }
+        data.update({key: value for key, value in optional_fields.items() if value})
+        return data
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def create_execution_lane_result(
+    objective: str,
+    sandbox_backend: Union[SandboxBackend, str],
+    status: Union[ExecutionStatus, str] = ExecutionStatus.PLANNED,
+    summary: str = "",
+    next_action: str = "",
+    **kwargs: Any,
+) -> ExecutionLaneResult:
+    """Create an execution result while keeping call sites terse."""
+
+    return ExecutionLaneResult(
+        objective=objective,
+        status=status,
+        sandbox_backend=sandbox_backend,
+        summary=summary,
+        next_action=next_action,
+        **kwargs,
+    )
+
+
+def score_execution_lane_result(result: ExecutionLaneResult) -> Dict[str, Any]:
+    """
+    Score whether an execution lane result is useful enough to hand off.
+
+    This is a lightweight local gate, not a replacement for a full Evalite suite.
+    It makes missing traceability visible before PopKit adopts any provider.
+    """
+
+    checks = {
+        "objective": bool(result.objective.strip()),
+        "sandboxBackend": isinstance(result.sandbox_backend, SandboxBackend),
+        "status": isinstance(result.status, ExecutionStatus),
+        "summary": bool(result.summary.strip()),
+        "nextAction": bool(result.next_action.strip()),
+        "trace": bool(result.commits or result.artifacts or result.log_path),
+        "validation": bool(result.validation),
+    }
+
+    warnings: List[str] = []
+    if result.status == ExecutionStatus.SUCCEEDED and any(
+        check.status == ValidationStatus.FAILED for check in result.validation
+    ):
+        checks["statusMatchesValidation"] = False
+    else:
+        checks["statusMatchesValidation"] = True
+
+    if result.validation and all(
+        check.status == ValidationStatus.NOT_RUN for check in result.validation
+    ):
+        warnings.append("validation checks were recorded but not run")
+
+    if result.status in {ExecutionStatus.PLANNED, ExecutionStatus.RUNNING}:
+        warnings.append("result is not terminal yet")
+
+    passed = [name for name, ok in checks.items() if ok]
+    missing = [name for name, ok in checks.items() if not ok]
+    score = round((len(passed) / len(checks)) * 100)
+
+    return {
+        "score": score,
+        "passed": passed,
+        "missing": missing,
+        "warnings": warnings,
+        "passedAll": not missing,
+    }
+
+
+__all__ = [
+    "ExecutionArtifact",
+    "ExecutionLaneResult",
+    "ExecutionStatus",
+    "SandboxBackend",
+    "ValidationCheck",
+    "ValidationStatus",
+    "create_execution_lane_result",
+    "score_execution_lane_result",
+]

--- a/packages/popkit-core/tests/power_mode/test_execution_spine.py
+++ b/packages/popkit-core/tests/power_mode/test_execution_spine.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Tests for the PopKit execution lane result contract."""
+
+import sys
+from pathlib import Path
+
+POWER_MODE_DIR = Path(__file__).resolve().parents[2] / "power-mode"
+sys.path.insert(0, str(POWER_MODE_DIR))
+
+from execution_spine import (  # noqa: E402
+    ExecutionArtifact,
+    ExecutionStatus,
+    SandboxBackend,
+    ValidationCheck,
+    ValidationStatus,
+    create_execution_lane_result,
+    score_execution_lane_result,
+)
+
+
+def test_execution_lane_result_serializes_canonical_shape():
+    result = create_execution_lane_result(
+        objective="Prototype safe execution result handoffs",
+        sandbox_backend=SandboxBackend.LOCAL_WORKTREE,
+        status=ExecutionStatus.SUCCEEDED,
+        branch="codex/example",
+        worktree_path="C:/worktrees/example",
+        log_path=".popkit/runs/example.log",
+        commits=["abc1234"],
+        artifacts=[
+            ExecutionArtifact(
+                kind="doc",
+                path="packages/docs/src/content/docs/concepts/execution-spine.md",
+                description="Execution spine design note",
+            )
+        ],
+        validation=[
+            ValidationCheck(
+                name="pytest",
+                status=ValidationStatus.PASSED,
+                command="python -m pytest packages/popkit-core/tests/power_mode",
+                summary="Power Mode tests passed",
+            )
+        ],
+        summary="Execution result was captured with traceability.",
+        next_action="Wire this result into the lane coordinator.",
+    )
+
+    data = result.to_dict()
+
+    assert data["status"] == "succeeded"
+    assert data["sandboxBackend"] == "local-worktree"
+    assert data["nextAction"] == "Wire this result into the lane coordinator."
+    assert data["artifacts"][0]["kind"] == "doc"
+    assert data["validation"][0]["status"] == "passed"
+    assert data["branch"] == "codex/example"
+
+    score = score_execution_lane_result(result)
+    assert score["passedAll"] is True
+    assert score["score"] == 100
+
+
+def test_execution_lane_result_accepts_provider_backends_as_strings():
+    result = create_execution_lane_result(
+        objective="Run in a future provider",
+        sandbox_backend="cloudflare-sandbox",
+        status="blocked",
+        summary="Provider adapter is not implemented yet.",
+        next_action="Keep the enum but do not add a dependency.",
+        artifacts=[
+            {
+                "kind": "decision",
+                "path": "packages/docs/src/content/docs/concepts/execution-spine.md",
+            }
+        ],
+        validation=[{"name": "adversarial-review", "status": "passed"}],
+    )
+
+    assert result.sandbox_backend == SandboxBackend.CLOUDFLARE_SANDBOX
+    assert result.status == ExecutionStatus.BLOCKED
+    assert result.to_dict()["sandboxBackend"] == "cloudflare-sandbox"
+
+
+def test_score_execution_lane_result_flags_missing_traceability():
+    result = create_execution_lane_result(
+        objective="",
+        sandbox_backend=SandboxBackend.NONE,
+        status=ExecutionStatus.SUCCEEDED,
+        summary="",
+        next_action="",
+    )
+
+    score = score_execution_lane_result(result)
+
+    assert score["passedAll"] is False
+    assert score["score"] < 60
+    assert "objective" in score["missing"]
+    assert "summary" in score["missing"]
+    assert "trace" in score["missing"]
+    assert "validation" in score["missing"]
+
+
+def test_score_execution_lane_result_rejects_success_with_failed_validation():
+    result = create_execution_lane_result(
+        objective="Ship a change",
+        sandbox_backend=SandboxBackend.E2B,
+        status=ExecutionStatus.SUCCEEDED,
+        summary="The lane says it succeeded.",
+        next_action="Fix the failing validation before handoff.",
+        log_path=".popkit/runs/lane.log",
+        validation=[ValidationCheck(name="unit-tests", status=ValidationStatus.FAILED)],
+    )
+
+    score = score_execution_lane_result(result)
+
+    assert score["passedAll"] is False
+    assert "statusMatchesValidation" in score["missing"]
+
+
+def test_provider_backend_enum_tracks_current_and_candidate_sandboxes():
+    assert SandboxBackend.E2B.value == "e2b"
+    assert SandboxBackend.LOCAL_WORKTREE.value == "local-worktree"
+    assert SandboxBackend.VERCEL_SANDBOX.value == "vercel-sandbox"
+    assert SandboxBackend.CLOUDFLARE_SANDBOX.value == "cloudflare-sandbox"


### PR DESCRIPTION
## Summary
- Add a provider-neutral ExecutionLaneResult contract for PopKit execution lanes
- Add output schema and registration for execution-lane-result
- Document the Sandcastle/Evalite/skills synthesis plus adversarial review in the docs

## Validation
- python -m pytest packages/popkit-core/tests/power_mode -q
- npx prettier --check packages/popkit-core/output-styles/schemas/execution-lane-result.schema.json packages/popkit-core/output-styles/schemas/README.md packages/docs/src/content/docs/concepts/execution-spine.md
- npm run docs:build

## Notes
- No Sandcastle, Evalite, Vercel, or Cloudflare runtime dependency was added.
- npm run lint:md is still blocked by pre-existing formatting drift in docs/research/2025-12-15-vibe-coded-benchmark-results.md.