### PR TITLE
feat(power-mode): emit execution lane results

### DIFF
--- a/packages/popkit-core/power-mode/shutdown_manager.py
+++ b/packages/popkit-core/power-mode/shutdown_manager.py
@@ -13,10 +13,19 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
+from execution_spine import (
+    ExecutionArtifact,
+    ExecutionStatus,
+    SandboxBackend,
+    ValidationCheck,
+    ValidationStatus,
+    create_execution_lane_result,
+    score_execution_lane_result,
+)
 from lifecycle import AgentLifecycle, AgentState
 from protocol import MessageFactory, ProtocolMessage
 
@@ -30,7 +39,7 @@ DEFAULT_STATE_FILE = (
 
 
 def _utc_timestamp() -> str:
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(UTC).isoformat()
 
 
 def _is_timeout_error(exc: Exception) -> bool:
@@ -47,9 +56,11 @@ class ShutdownSummary:
     request_ids: Dict[str, str] = field(default_factory=dict)
     cleanup_called: bool = False
     events: List[str] = field(default_factory=list)
+    execution_result: Optional[Dict[str, Any]] = None
+    execution_result_score: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        data: Dict[str, Any] = {
             "total_agents": self.total_agents,
             "graceful_exits": self.graceful_exits,
             "forced_exits": self.forced_exits,
@@ -57,6 +68,11 @@ class ShutdownSummary:
             "cleanup_called": self.cleanup_called,
             "events": self.events,
         }
+        if self.execution_result is not None:
+            data["execution_result"] = self.execution_result
+        if self.execution_result_score is not None:
+            data["execution_result_score"] = self.execution_result_score
+        return data
 
 
 class GracefulShutdownManager:
@@ -194,7 +210,7 @@ class GracefulShutdownManager:
             try:
                 await asyncio.wait_for(wait_fn(), timeout=timeout_seconds)
                 return True
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 return False
 
         try:
@@ -223,7 +239,7 @@ class GracefulShutdownManager:
         try:
             await asyncio.wait_for(asyncio.to_thread(wait_fn), timeout=timeout_seconds)
             return True
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return False
 
     def _send_terminate(self, process: Any, agent: str) -> None:
@@ -273,6 +289,7 @@ class GracefulShutdownManager:
             "forced_exits": list(summary.forced_exits),
             "request_ids": dict(summary.request_ids),
         }
+        self._attach_execution_result(state, summary)
 
         self.state_file.parent.mkdir(parents=True, exist_ok=True)
         self.state_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
@@ -291,3 +308,83 @@ class GracefulShutdownManager:
         summary.cleanup_called = True
         summary.events.append("cleanup:callback")
         logger.debug("Cleanup callback executed")
+
+    def _attach_execution_result(
+        self,
+        state: Dict[str, Any],
+        summary: ShutdownSummary,
+    ) -> None:
+        """Attach the canonical execution result to the final state snapshot."""
+        result = create_execution_lane_result(
+            objective=str(state.get("objective") or "Power Mode session"),
+            sandbox_backend=_sandbox_backend_from_state(state),
+            status=(ExecutionStatus.FAILED if summary.forced_exits else ExecutionStatus.SUCCEEDED),
+            branch=_optional_string(state.get("branch")),
+            worktree_path=_optional_string(state.get("worktree_path")),
+            log_path=_optional_string(state.get("log_path")),
+            provider_run_id=_optional_string(state.get("provider_run_id")),
+            commits=[str(commit) for commit in (state.get("commits") or [])],
+            artifacts=[
+                ExecutionArtifact(
+                    kind="state",
+                    path=str(self.state_file),
+                    description="Power Mode state file updated at shutdown",
+                )
+            ],
+            validation=[
+                ValidationCheck(
+                    name="graceful-shutdown",
+                    status=(
+                        ValidationStatus.FAILED if summary.forced_exits else ValidationStatus.PASSED
+                    ),
+                    summary=(
+                        f"{len(summary.graceful_exits)} graceful exit(s), "
+                        f"{len(summary.forced_exits)} forced exit(s)"
+                    ),
+                )
+            ],
+            summary=(
+                f"Power Mode shutdown completed for {summary.total_agents} agent(s): "
+                f"{len(summary.graceful_exits)} graceful, "
+                f"{len(summary.forced_exits)} forced."
+            ),
+            next_action=(
+                "Review forced exits before continuing."
+                if summary.forced_exits
+                else "Review execution artifacts and continue with the next lane."
+            ),
+            started_at=str(state.get("started_at") or _utc_timestamp()),
+            completed_at=str(state["deactivated_at"]),
+            metadata={
+                "session_id": state.get("session_id"),
+                "mode": state.get("mode"),
+                "issues": state.get("issues") or [],
+                "shutdown": state["shutdown"],
+            },
+        )
+        result_data = result.to_dict()
+        score = score_execution_lane_result(result)
+        state["execution_result"] = result_data
+        state["execution_result_score"] = score
+        summary.execution_result = result_data
+        summary.execution_result_score = score
+
+
+def _sandbox_backend_from_state(state: Dict[str, Any]) -> SandboxBackend:
+    mode = str(state.get("sandbox_backend") or state.get("mode") or "").lower()
+    if "e2b" in mode:
+        return SandboxBackend.E2B
+    if "worktree" in mode or "local" in mode:
+        return SandboxBackend.LOCAL_WORKTREE
+    if "vercel" in mode:
+        return SandboxBackend.VERCEL_SANDBOX
+    if "cloudflare" in mode:
+        return SandboxBackend.CLOUDFLARE_SANDBOX
+    return SandboxBackend.NONE
+
+
+def _optional_string(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value)
+    return text or None

--- a/packages/popkit-core/tests/power_mode/test_shutdown_manager.py
+++ b/packages/popkit-core/tests/power_mode/test_shutdown_manager.py
@@ -66,13 +66,32 @@ def test_shutdown_graceful_exit_updates_state_file(tmp_path):
     assert saved_state["active"] is False
     assert "deactivated_at" in saved_state
     assert saved_state["shutdown"]["graceful_exits"] == ["agent-1"]
+    assert saved_state["execution_result"]["objective"] == "Power Mode session"
+    assert saved_state["execution_result"]["status"] == "succeeded"
+    assert saved_state["execution_result"]["sandboxBackend"] == "none"
+    assert saved_state["execution_result"]["validation"][0]["status"] == "passed"
+    assert saved_state["execution_result_score"]["passedAll"] is True
+    assert summary["execution_result"]["status"] == "succeeded"
 
 
 def test_shutdown_timeout_force_kills_stragglers(tmp_path):
+    state_file = tmp_path / "power-mode-state.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "active": True,
+                "session_id": "power-123",
+                "objective": "Finish execution spine lane",
+                "mode": "e2b",
+                "started_at": "2026-04-30T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
     process = AsyncProcess(delay=1.0)
     manager = GracefulShutdownManager(
         {"agent-2": process},
-        state_file=tmp_path / "power-mode-state.json",
+        state_file=state_file,
     )
 
     summary = asyncio.run(manager.shutdown(timeout_seconds=0.01))
@@ -81,6 +100,13 @@ def test_shutdown_timeout_force_kills_stragglers(tmp_path):
     assert summary["forced_exits"] == ["agent-2"]
     assert process.terminate_calls == 1
     assert process.kill_calls == 1
+
+    saved_state = json.loads(state_file.read_text(encoding="utf-8"))
+    assert saved_state["execution_result"]["objective"] == "Finish execution spine lane"
+    assert saved_state["execution_result"]["status"] == "failed"
+    assert saved_state["execution_result"]["sandboxBackend"] == "e2b"
+    assert saved_state["execution_result"]["validation"][0]["status"] == "failed"
+    assert saved_state["execution_result"]["nextAction"] == "Review forced exits before continuing."
 
 
 def test_send_shutdown_request_awaits_async_dispatcher(tmp_path):

--- a/packages/shared-py/popkit_shared/utils/subprocess_utils.py
+++ b/packages/shared-py/popkit_shared/utils/subprocess_utils.py
@@ -17,9 +17,23 @@ Usage:
     output, success = run_command_simple("git status")
 """
 
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Union
+
+
+def _resolve_command_executable(cmd_list: list[str]) -> list[str]:
+    """Resolve command names to executable paths for cross-platform subprocess use."""
+    if not cmd_list:
+        return cmd_list
+
+    executable = cmd_list[0]
+    resolved = shutil.which(executable)
+    if not resolved:
+        return cmd_list
+
+    return [resolved, *cmd_list[1:]]
 
 
 def run_command(
@@ -60,6 +74,9 @@ def run_command(
             cmd_list = cmd.split()
         else:
             cmd_list = cmd
+
+        if isinstance(cmd_list, list) and not shell:
+            cmd_list = _resolve_command_executable(cmd_list)
 
         # Normalize cwd to string if Path
         cwd_str = str(cwd) if cwd else None

--- a/packages/shared-py/tests/utils/test_subprocess_utils.py
+++ b/packages/shared-py/tests/utils/test_subprocess_utils.py
@@ -6,10 +6,12 @@ Issue #303: Consolidate duplicated run_command function
 """
 
 import subprocess
+import sys
 
 import pytest
 
 from popkit_shared.utils.subprocess_utils import (
+    _resolve_command_executable,
     run_command,
     run_command_checked,
     run_command_full,
@@ -21,18 +23,31 @@ from popkit_shared.utils.subprocess_utils import (
 class TestRunCommand:
     """Tests for run_command (full result)."""
 
+    def test_resolves_executable_for_list_command(self, monkeypatch):
+        """Test list commands resolve platform-specific executables."""
+        monkeypatch.setattr(
+            "popkit_shared.utils.subprocess_utils.shutil.which",
+            lambda name: "/mock/npm.cmd" if name == "npm" else None,
+        )
+
+        assert _resolve_command_executable(["npm", "run", "lint:ts"]) == [
+            "/mock/npm.cmd",
+            "run",
+            "lint:ts",
+        ]
+
     def test_successful_command_with_list(self):
         """Test successful command with list input."""
-        exit_code, stdout, stderr = run_command(["echo", "hello"])
+        exit_code, stdout, stderr = run_command([sys.executable, "-c", "print('hello')"])
         assert exit_code == 0
         assert "hello" in stdout
         assert stderr == ""
 
     def test_successful_command_with_string(self):
         """Test successful command with string input."""
-        exit_code, stdout, stderr = run_command("echo hello")
+        exit_code, stdout, stderr = run_command("git --version")
         assert exit_code == 0
-        assert "hello" in stdout
+        assert "git version" in stdout.lower()
 
     def test_command_with_cwd(self, tmp_path):
         """Test command with working directory."""
@@ -40,14 +55,22 @@ class TestRunCommand:
         test_file = tmp_path / "test.txt"
         test_file.write_text("content")
 
-        # Run command in that directory
-        exit_code, stdout, stderr = run_command(["ls"], cwd=tmp_path)
+        exit_code, stdout, stderr = run_command(
+            [
+                sys.executable,
+                "-c",
+                "from pathlib import Path; print('\\n'.join(p.name for p in Path('.').iterdir()))",
+            ],
+            cwd=tmp_path,
+        )
         assert exit_code == 0
         assert "test.txt" in stdout
 
     def test_command_with_path_cwd(self, tmp_path):
         """Test command with Path object as cwd."""
-        exit_code, stdout, stderr = run_command(["pwd"], cwd=tmp_path)
+        exit_code, stdout, stderr = run_command(
+            [sys.executable, "-c", "import os; print(os.getcwd())"], cwd=tmp_path
+        )
         assert exit_code == 0
 
     def test_failed_command(self):
@@ -58,7 +81,9 @@ class TestRunCommand:
     def test_timeout_handling(self):
         """Test command timeout."""
         # This command would hang without timeout
-        exit_code, stdout, stderr = run_command(["sleep", "10"], timeout=1)
+        exit_code, stdout, stderr = run_command(
+            [sys.executable, "-c", "import time; time.sleep(10)"], timeout=1
+        )
         assert exit_code == -1
         assert "timed out" in stderr.lower()
 
@@ -70,7 +95,7 @@ class TestRunCommand:
 
     def test_output_stripped(self):
         """Test that output is stripped of whitespace."""
-        exit_code, stdout, stderr = run_command(["echo", "  hello  "])
+        exit_code, stdout, stderr = run_command([sys.executable, "-c", "print('  hello  ')"])
         # echo adds its own newline, but we strip
         assert stdout.strip() == "hello"
 
@@ -80,23 +105,34 @@ class TestRunCommandSimple:
 
     def test_successful_command(self):
         """Test successful command returns output and True."""
-        output, success = run_command_simple("echo hello")
+        output, success = run_command_simple([sys.executable, "-c", "print('hello')"])
         assert success is True
         assert "hello" in output
 
     def test_failed_command(self):
         """Test failed command returns error and False."""
-        output, success = run_command_simple("ls /nonexistent_directory_12345")
+        output, success = run_command_simple(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.stderr.write('missing\\n'); sys.exit(2)",
+            ]
+        )
         assert success is False
+        assert "missing" in output
 
     def test_with_cwd(self, tmp_path):
         """Test command with working directory."""
-        output, success = run_command_simple("pwd", cwd=tmp_path)
+        output, success = run_command_simple(
+            [sys.executable, "-c", "import os; print(os.getcwd())"], cwd=tmp_path
+        )
         assert success is True
 
     def test_timeout(self):
         """Test timeout returns error message and False."""
-        output, success = run_command_simple("sleep 10", timeout=1)
+        output, success = run_command_simple(
+            [sys.executable, "-c", "import time; time.sleep(10)"], timeout=1
+        )
         assert success is False
         assert "timed out" in output.lower()
 
@@ -106,7 +142,7 @@ class TestRunCommandChecked:
 
     def test_successful_command(self):
         """Test successful command returns output."""
-        output = run_command_checked("echo hello")
+        output = run_command_checked([sys.executable, "-c", "print('hello')"])
         assert "hello" in output
 
     def test_failed_command_raises(self):
@@ -118,7 +154,7 @@ class TestRunCommandChecked:
     def test_timeout_raises(self):
         """Test timeout raises RuntimeError."""
         with pytest.raises(RuntimeError) as exc_info:
-            run_command_checked("sleep 10", timeout=1)
+            run_command_checked([sys.executable, "-c", "import time; time.sleep(10)"], timeout=1)
         assert "timed out" in str(exc_info.value).lower()
 
 
@@ -152,7 +188,9 @@ class TestRunCommandFull:
 
     def test_legacy_signature(self, tmp_path):
         """Test legacy signature works."""
-        exit_code, stdout, stderr = run_command_full(["echo", "hello"], str(tmp_path), timeout=30)
+        exit_code, stdout, stderr = run_command_full(
+            [sys.executable, "-c", "print('hello')"], str(tmp_path), timeout=30
+        )
         assert exit_code == 0
         assert "hello" in stdout
 
@@ -167,20 +205,20 @@ class TestEdgeCases:
 
     def test_command_with_special_chars(self):
         """Test command with special characters in output."""
-        exit_code, stdout, stderr = run_command(["echo", "hello\tworld"])
+        exit_code, stdout, stderr = run_command([sys.executable, "-c", "print('hello\\tworld')"])
         assert exit_code == 0
 
     def test_large_output(self):
         """Test handling of large output."""
         # Generate large output
-        exit_code, stdout, stderr = run_command(["python", "-c", "print('x' * 10000)"])
+        exit_code, stdout, stderr = run_command([sys.executable, "-c", "print('x' * 10000)"])
         assert exit_code == 0
         assert len(stdout) >= 10000
 
     def test_stderr_capture(self):
         """Test that stderr is captured separately."""
         exit_code, stdout, stderr = run_command(
-            ["python", "-c", "import sys; sys.stderr.write('error\\n')"]
+            [sys.executable, "-c", "import sys; sys.stderr.write('error\\n')"]
         )
         assert exit_code == 0
         assert "error" in stderr


### PR DESCRIPTION
## Summary
- Emit `ExecutionLaneResult` from Power Mode graceful shutdown state snapshots
- Include execution-result scoring in shutdown summaries and persisted state
- Fix Windows command resolution in shared subprocess utilities so `npx`/`npm`-backed analyzers work
- Make subprocess utility tests cross-platform instead of relying on Unix shell commands

## Validation
- python -m pytest packages/popkit-core/tests/power_mode packages/shared-py/tests/utils/test_subprocess_utils.py -q
- npm run lint:py
- npm run lint:ts
- python packages/popkit-dev/skills/pop-next-action/scripts/analyze_state.py --section code

## Notes
- `popkit-next` now reports TypeScript as clean instead of unknown on this Windows checkout.
- Stale local branches were audited but not deleted because none are clearly merged into main by git reachability.