### PR TITLE
chore(release): sync install surfaces

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,20 +6,20 @@
   },
   "metadata": {
     "description": "PopKit modular plugin suite - official marketplace",
-    "version": "1.0.0-beta.12"
+    "version": "1.0.0-beta.13"
   },
   "plugins": [
     {
       "name": "popkit-core",
       "source": "./packages/popkit-core",
       "description": "Core utilities plugin - plugin management, project analysis, Power Mode orchestration, stats, privacy, and meta-features",
-      "version": "1.0.0-beta.12",
+      "version": "1.0.0-beta.13",
       "author": {
         "name": "Joseph Cannon",
         "email": "joseph@thehouseofdeals.com"
       },
-      "homepage": "https://github.com/jrc1883/popkit-claude",
-      "repository": "https://github.com/jrc1883/popkit-claude",
+      "homepage": "https://github.com/jrc1883/popkit-ai",
+      "repository": "https://github.com/jrc1883/popkit-ai",
       "license": "MIT",
       "keywords": ["popkit", "foundation", "account", "stats", "privacy", "power-mode"],
       "category": "productivity",
@@ -47,13 +47,13 @@
       "name": "popkit-dev",
       "source": "./packages/popkit-dev",
       "description": "Development workflow plugin - feature development, git operations, GitHub integration, and daily routines",
-      "version": "1.0.0-beta.12",
+      "version": "1.0.0-beta.13",
       "author": {
         "name": "Joseph Cannon",
         "email": "joseph@thehouseofdeals.com"
       },
-      "homepage": "https://github.com/jrc1883/popkit-claude",
-      "repository": "https://github.com/jrc1883/popkit-claude",
+      "homepage": "https://github.com/jrc1883/popkit-ai",
+      "repository": "https://github.com/jrc1883/popkit-ai",
       "license": "MIT",
       "keywords": ["development", "workflow", "git", "github", "routines"],
       "category": "productivity",
@@ -81,13 +81,13 @@
       "name": "popkit-ops",
       "source": "./packages/popkit-ops",
       "description": "Operations plugin - quality assurance, deployment automation, debugging workflows, and security scanning",
-      "version": "1.0.0-beta.12",
+      "version": "1.0.0-beta.13",
       "author": {
         "name": "Joseph Cannon",
         "email": "joseph@thehouseofdeals.com"
       },
-      "homepage": "https://github.com/jrc1883/popkit-claude",
-      "repository": "https://github.com/jrc1883/popkit-claude",
+      "homepage": "https://github.com/jrc1883/popkit-ai",
+      "repository": "https://github.com/jrc1883/popkit-ai",
       "license": "MIT",
       "keywords": ["operations", "quality", "deployment", "security", "debugging"],
       "category": "productivity",
@@ -111,13 +111,13 @@
       "name": "popkit-research",
       "source": "./packages/popkit-research",
       "description": "Research plugin - knowledge management, research capture, and semantic search for development insights",
-      "version": "1.0.0-beta.12",
+      "version": "1.0.0-beta.13",
       "author": {
         "name": "Joseph Cannon",
         "email": "joseph@thehouseofdeals.com"
       },
-      "homepage": "https://github.com/jrc1883/popkit-claude",
-      "repository": "https://github.com/jrc1883/popkit-claude",
+      "homepage": "https://github.com/jrc1883/popkit-ai",
+      "repository": "https://github.com/jrc1883/popkit-ai",
       "license": "MIT",
       "keywords": ["research", "knowledge", "documentation"],
       "category": "productivity",

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -123,7 +123,7 @@ template: |
   ## Installation
 
   ```
-  /plugin marketplace add jrc1883/popkit-claude
+  /plugin marketplace add jrc1883/popkit-ai
   /plugin install popkit@popkit-claude
   ```
 

--- a/.github/scripts/prepare-public-plugin.sh
+++ b/.github/scripts/prepare-public-plugin.sh
@@ -196,7 +196,7 @@ AI-powered development workflows for Claude Code.
 ## Installation
 
 ```
-/plugin marketplace add jrc1883/popkit-claude
+/plugin marketplace add jrc1883/popkit-ai
 /plugin install popkit@popkit-claude
 ```
 
@@ -301,4 +301,4 @@ echo "Commands: $(ls -1 "$OUTPUT_DIR/commands" 2>/dev/null | wc -l)"
 echo "Skills: $(ls -1 "$OUTPUT_DIR/skills" 2>/dev/null | wc -l)"
 echo "Agents: $(find "$OUTPUT_DIR/agents" -name "AGENT.md" 2>/dev/null | wc -l)"
 echo ""
-echo "Ready to push to jrc1883/popkit-claude"
+echo "Ready to push to jrc1883/popkit-ai"

--- a/.github/scripts/validate_marketplace.py
+++ b/.github/scripts/validate_marketplace.py
@@ -1,26 +1,128 @@
 #!/usr/bin/env python3
 """
-Validate root marketplace.json contains all expected plugins.
-Usage: python validate_marketplace.py
+Validate PopKit marketplace release metadata.
+
+Checks the install-facing marketplace files, package plugin manifests, and
+universal package manifests stay version-aligned.
 """
 
+from __future__ import annotations
+
 import json
+import re
 import sys
+from pathlib import Path
 
-try:
-    with open(".claude-plugin/marketplace.json") as f:
-        marketplace = json.load(f)
-except Exception as e:
-    print(f"Error: Failed to read marketplace.json: {e}")
-    sys.exit(1)
+EXPECTED_PLUGINS = ["popkit-core", "popkit-dev", "popkit-ops", "popkit-research"]
+REPOSITORY_URL = "https://github.com/jrc1883/popkit-ai"
 
-expected_plugins = ["popkit-core", "popkit-dev", "popkit-ops", "popkit-research"]
-actual_plugins = [p["name"] for p in marketplace.get("plugins", [])]
 
-missing = set(expected_plugins) - set(actual_plugins)
-if missing:
-    print(f"Error: Plugins missing from marketplace: {missing}")
-    sys.exit(1)
+def load_json(path: Path) -> dict:
+    try:
+        with path.open(encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as exc:
+        raise ValueError(f"failed to read {path}: {exc}") from exc
 
-print(f"✓ All {len(actual_plugins)} plugins listed in marketplace")
-print(f"✓ Marketplace version: {marketplace.get('metadata', {}).get('version', 'unknown')}")
+
+def read_yaml_field(path: Path, field: str) -> str | None:
+    pattern = re.compile(rf"^{re.escape(field)}:\s*(.+?)\s*$")
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = pattern.match(line)
+        if match:
+            return match.group(1).strip().strip("'\"")
+    return None
+
+
+def require(condition: bool, message: str, errors: list[str]) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def validate_marketplace(path: Path, errors: list[str]) -> str | None:
+    marketplace = load_json(path)
+    version = marketplace.get("metadata", {}).get("version")
+    plugins = marketplace.get("plugins", [])
+    actual_plugins = [plugin.get("name") for plugin in plugins]
+
+    missing = sorted(set(EXPECTED_PLUGINS) - set(actual_plugins))
+    extra = sorted(set(actual_plugins) - set(EXPECTED_PLUGINS))
+    require(not missing, f"{path}: missing plugins {missing}", errors)
+    require(not extra, f"{path}: unexpected plugins {extra}", errors)
+    require(bool(version), f"{path}: missing metadata.version", errors)
+
+    for plugin in plugins:
+        name = plugin.get("name", "<unknown>")
+        require(
+            plugin.get("version") == version,
+            f"{path}: {name} version {plugin.get('version')} != marketplace {version}",
+            errors,
+        )
+        require(
+            plugin.get("repository") == REPOSITORY_URL,
+            f"{path}: {name} repository should be {REPOSITORY_URL}",
+            errors,
+        )
+
+    return version
+
+
+def validate_package_manifests(version: str, errors: list[str]) -> None:
+    for plugin_name in EXPECTED_PLUGINS:
+        plugin_json = Path("packages") / plugin_name / ".claude-plugin" / "plugin.json"
+        package_yaml = Path("packages") / plugin_name / "popkit-package.yaml"
+
+        plugin_manifest = load_json(plugin_json)
+        require(
+            plugin_manifest.get("version") == version,
+            f"{plugin_json}: version {plugin_manifest.get('version')} != {version}",
+            errors,
+        )
+        require(
+            plugin_manifest.get("repository") == REPOSITORY_URL,
+            f"{plugin_json}: repository should be {REPOSITORY_URL}",
+            errors,
+        )
+
+        yaml_version = read_yaml_field(package_yaml, "version")
+        yaml_repository = read_yaml_field(package_yaml, "repository")
+        require(
+            yaml_version == version, f"{package_yaml}: version {yaml_version} != {version}", errors
+        )
+        require(
+            yaml_repository == REPOSITORY_URL,
+            f"{package_yaml}: repository should be {REPOSITORY_URL}",
+            errors,
+        )
+
+
+def main() -> int:
+    errors: list[str] = []
+    versions = []
+
+    for path in [Path(".claude-plugin/marketplace.json"), Path("marketplace.json")]:
+        versions.append(validate_marketplace(path, errors))
+
+    require(
+        len(set(versions)) == 1,
+        f"marketplace versions differ: {versions}",
+        errors,
+    )
+
+    if versions[0]:
+        validate_package_manifests(versions[0], errors)
+
+    if errors:
+        print("Marketplace validation failed:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print(f"All {len(EXPECTED_PLUGINS)} plugins listed in both marketplace files")
+    print(f"Marketplace version: {versions[0]}")
+    print(f"Repository URL: {REPOSITORY_URL}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -1,7 +1,7 @@
 # Publish Plugin to Public Repository
 #
 # This workflow syncs packages/plugin/ from the private monorepo to the
-# public jrc1883/popkit-claude repository for open-source distribution.
+# public jrc1883/popkit-ai repository for open-source distribution.
 #
 # NOTE: This workflow now uses a FILTERED publish approach that excludes
 # implementation code (power-mode, templates, hooks/utils). Only declarative
@@ -12,7 +12,7 @@
 # - Push to master when packages/plugin/ changes (optional auto-sync)
 #
 # Required Secrets:
-# - PLUGIN_PUBLIC_REPO_TOKEN: PAT with repo scope for jrc1883/popkit-claude
+# - PLUGIN_PUBLIC_REPO_TOKEN: PAT with repo scope for jrc1883/popkit-ai
 
 name: Publish Plugin
 
@@ -68,7 +68,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PLUGIN_PUBLIC_REPO_TOKEN }}
         run: |
           git remote add plugin-public \
-            "https://x-access-token:${GITHUB_TOKEN}@github.com/jrc1883/popkit-claude.git"
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/jrc1883/popkit-ai.git"
           echo "Remote added: plugin-public"
 
       - name: Prepare filtered plugin content
@@ -96,7 +96,7 @@ jobs:
             echo "=== DRY RUN - No changes will be pushed ==="
             echo ""
             echo "Source: packages/plugin/ (filtered)"
-            echo "Target: jrc1883/popkit-claude (${{ inputs.target_branch || 'main' }})"
+            echo "Target: jrc1883/popkit-ai (${{ inputs.target_branch || 'main' }})"
             echo "Prepared SHA: ${{ steps.prepare.outputs.sha }}"
             echo ""
             echo "Files in filtered content:"
@@ -109,10 +109,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PLUGIN_PUBLIC_REPO_TOKEN }}
         run: |
           TARGET_BRANCH="${{ inputs.target_branch || 'main' }}"
-          echo "Pushing to jrc1883/popkit-claude (${TARGET_BRANCH})..."
+          echo "Pushing to jrc1883/popkit-ai (${TARGET_BRANCH})..."
 
           cd 'public-plugin-staging'
-          git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/jrc1883/popkit-claude.git"
+          git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/jrc1883/popkit-ai.git"
           git push origin "HEAD:${TARGET_BRANCH}" --force
 
           echo "Push complete!"
@@ -140,7 +140,7 @@ jobs:
 
           # Create release in public repo
           gh release create "${VERSION}" \
-            --repo 'jrc1883/popkit-claude' \
+            --repo 'jrc1883/popkit-ai' \
             --title "PopKit Claude ${VERSION}" \
             --notes "## What's Changed
 
@@ -149,7 +149,7 @@ jobs:
           ## Installation
 
           \`\`\`
-          /plugin marketplace add jrc1883/popkit-claude
+          /plugin marketplace add jrc1883/popkit-ai
           /plugin install popkit@popkit-claude
           \`\`\`
 
@@ -164,7 +164,7 @@ jobs:
             echo "| Property | Value |"
             echo "|----------|-------|"
             echo "| Source | \`packages/plugin/\` (filtered) |"
-            echo "| Target | \`jrc1883/popkit-claude\` |"
+            echo "| Target | \`jrc1883/popkit-ai\` |"
             echo "| Branch | \`${{ inputs.target_branch || 'main' }}\` |"
             echo "| Version | ${{ inputs.version || 'none' }} |"
             echo "| Dry Run | ${{ inputs.dry_run }} |"
@@ -175,7 +175,7 @@ jobs:
             {
               echo "### Installation"
               echo "\`\`\`"
-              echo "/plugin marketplace add jrc1883/popkit-claude"
+              echo "/plugin marketplace add jrc1883/popkit-ai"
               echo "/plugin install popkit@popkit-claude"
               echo "\`\`\`"
             } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to PopKit are documented in this file.
 
 **Versioning:** PopKit uses semantic versioning. Currently in public beta (1.0.0-beta).
 
+## [1.0.0-beta.13] - 2026-04-30
+
+### Added
+
+- Execution spine contract for Power Mode runs, including typed execution lanes, validation checks, artifacts, and output style documentation.
+- Power Mode shutdown emission for structured `execution_result` payloads so downstream tools can inspect run status, artifacts, validation, and commits.
+
+### Changed
+
+- Release metadata now points at the current `jrc1883/popkit-ai` repository while preserving the existing `popkit-claude` marketplace name for install compatibility.
+- Python package metadata prepared for `1.0.2` releases across `popkit`, `popkit-shared`, `popkit-cli`, and `popkit-mcp`.
+
+### Fixed
+
+- Windows analyzer subprocess resolution now handles `.CMD` shims correctly via resolved executable paths.
+- Marketplace, plugin, and package manifests are aligned with the current source state for the next public release.
+
 ## [1.0.0-beta.12] - 2026-03-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Example: `/popkit-dev:next` uses `pop-next-action` internally, then adds [mode h
 
 ```bash
 # Add the PopKit marketplace
-/plugin marketplace add jrc1883/popkit-claude
+/plugin marketplace add jrc1883/popkit-ai
 
 # Install the plugins you need
 /plugin install popkit-core@popkit-claude   # Foundation
@@ -266,7 +266,7 @@ PopKit is modular. Install what you need:
 
 ## Status
 
-**Version:** 1.0.0-beta.12
+**Version:** 1.0.0-beta.13
 **Status:** Public beta — core features stable, actively improving
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 # PopKit Roadmap
 
-**Last Updated:** 2026-03-23
-**Current Version:** 1.0.0-beta.12
+**Last Updated:** 2026-04-30
+**Current Version:** 1.0.0-beta.13
 **Current Focus:** v2 LLM-agnostic orchestration engine — multi-provider support, PyPI publishing, documentation.
 
 ## Principles

--- a/marketplace.json
+++ b/marketplace.json
@@ -6,16 +6,16 @@
   },
   "metadata": {
     "description": "PopKit modular plugin suite - official marketplace",
-    "version": "1.0.0-beta.12"
+    "version": "1.0.0-beta.13"
   },
   "plugins": [
     {
       "name": "popkit-core",
       "source": "./packages/popkit-core",
       "description": "Core utilities plugin - plugin management, project analysis, Power Mode orchestration, stats, privacy, and meta-features",
-      "version": "1.0.0-beta.12",
-      "homepage": "https://github.com/jrc1883/popkit-claude/tree/main/packages/popkit-core",
-      "repository": "https://github.com/jrc1883/popkit-claude",
+      "version": "1.0.0-beta.13",
+      "homepage": "https://github.com/jrc1883/popkit-ai/tree/main/packages/popkit-core",
+      "repository": "https://github.com/jrc1883/popkit-ai",
       "license": "MIT",
       "keywords": ["development", "workflow", "automation", "power-mode"],
       "author": {
@@ -47,9 +47,9 @@
       "name": "popkit-dev",
       "source": "./packages/popkit-dev",
       "description": "Development workflow plugin - feature development, git operations, GitHub integration, and daily routines",
-      "version": "1.0.0-beta.12",
-      "homepage": "https://github.com/jrc1883/popkit-claude/tree/main/packages/popkit-dev",
-      "repository": "https://github.com/jrc1883/popkit-claude",
+      "version": "1.0.0-beta.13",
+      "homepage": "https://github.com/jrc1883/popkit-ai/tree/main/packages/popkit-dev",
+      "repository": "https://github.com/jrc1883/popkit-ai",
       "license": "MIT",
       "keywords": ["git", "github", "workflow", "development"],
       "author": {
@@ -81,9 +81,9 @@
       "name": "popkit-ops",
       "source": "./packages/popkit-ops",
       "description": "Operations plugin - quality assurance, deployment automation, debugging workflows, and security scanning",
-      "version": "1.0.0-beta.12",
-      "homepage": "https://github.com/jrc1883/popkit-claude/tree/main/packages/popkit-ops",
-      "repository": "https://github.com/jrc1883/popkit-claude",
+      "version": "1.0.0-beta.13",
+      "homepage": "https://github.com/jrc1883/popkit-ai/tree/main/packages/popkit-ops",
+      "repository": "https://github.com/jrc1883/popkit-ai",
       "license": "MIT",
       "keywords": ["ops", "deployment", "testing", "security"],
       "author": {
@@ -111,9 +111,9 @@
       "name": "popkit-research",
       "source": "./packages/popkit-research",
       "description": "Research plugin - knowledge management, research capture, and semantic search for development insights",
-      "version": "1.0.0-beta.12",
-      "homepage": "https://github.com/jrc1883/popkit-claude/tree/main/packages/popkit-research",
-      "repository": "https://github.com/jrc1883/popkit-claude",
+      "version": "1.0.0-beta.13",
+      "homepage": "https://github.com/jrc1883/popkit-ai/tree/main/packages/popkit-research",
+      "repository": "https://github.com/jrc1883/popkit-ai",
       "license": "MIT",
       "keywords": ["research", "knowledge", "documentation"],
       "author": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jrc1883/popkit-claude.git"
+    "url": "git+https://github.com/jrc1883/popkit-ai.git"
   },
   "keywords": [
     "claude-code",
@@ -44,9 +44,9 @@
   "author": "Joseph Cannon",
   "license": "PolyForm-Noncommercial-1.0.0",
   "bugs": {
-    "url": "https://github.com/jrc1883/popkit-claude/issues"
+    "url": "https://github.com/jrc1883/popkit-ai/issues"
   },
-  "homepage": "https://github.com/jrc1883/popkit-claude#readme",
+  "homepage": "https://github.com/jrc1883/popkit-ai#readme",
   "engines": {
     "node": ">=20.3.0",
     "npm": ">=9.6.5"

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -13,7 +13,7 @@ export default defineConfig({
         {
           icon: "github",
           label: "GitHub",
-          href: "https://github.com/jrc1883/popkit-claude",
+          href: "https://github.com/jrc1883/popkit-ai",
         },
       ],
       sidebar: [

--- a/packages/docs/src/content/docs/getting-started/installation.md
+++ b/packages/docs/src/content/docs/getting-started/installation.md
@@ -7,11 +7,11 @@ description: How to install PopKit — Claude Code plugin, PyPI packages, or MCP
 
 PopKit can be installed in three ways depending on your setup:
 
-| Method                 | Best for                                   | Install command                                 |
-| ---------------------- | ------------------------------------------ | ----------------------------------------------- |
-| **Claude Code plugin** | Claude Code users                          | `/plugin marketplace add jrc1883/popkit-claude` |
-| **PyPI (MCP server)**  | Cursor, Codex CLI, Copilot, any MCP client | `pip install popkit-mcp`                        |
-| **PyPI (full)**        | Standalone CLI + all utilities             | `pip install popkit[full]`                      |
+| Method                 | Best for                                   | Install command                             |
+| ---------------------- | ------------------------------------------ | ------------------------------------------- |
+| **Claude Code plugin** | Claude Code users                          | `/plugin marketplace add jrc1883/popkit-ai` |
+| **PyPI (MCP server)**  | Cursor, Codex CLI, Copilot, any MCP client | `pip install popkit-mcp`                    |
+| **PyPI (full)**        | Standalone CLI + all utilities             | `pip install popkit[full]`                  |
 
 ---
 
@@ -20,7 +20,7 @@ PopKit can be installed in three ways depending on your setup:
 ### Step 1: Add the Marketplace (One-time Setup)
 
 ```bash
-/plugin marketplace add jrc1883/popkit-claude
+/plugin marketplace add jrc1883/popkit-ai
 ```
 
 ### Step 2: Install Plugins

--- a/packages/docs/src/content/docs/guides/mcp-providers.md
+++ b/packages/docs/src/content/docs/guides/mcp-providers.md
@@ -105,7 +105,7 @@ Click the badge to auto-configure PopKit in VS Code. Requires `pip install popki
 Claude Code users should install PopKit as a plugin instead of using MCP:
 
 ```bash
-/plugin marketplace add jrc1883/popkit-claude
+/plugin marketplace add jrc1883/popkit-ai
 /plugin install popkit-core@popkit-claude
 ```
 

--- a/packages/docs/src/content/docs/guides/troubleshooting.md
+++ b/packages/docs/src/content/docs/guides/troubleshooting.md
@@ -106,7 +106,7 @@ Cursor has a limit of approximately 40 tools across all MCP servers. If you have
 3. If popkit-claude isn't listed, re-add it:
 
 ```bash
-/plugin marketplace add jrc1883/popkit-claude
+/plugin marketplace add jrc1883/popkit-ai
 ```
 
 ### Plugin version mismatch
@@ -169,5 +169,5 @@ If agents are failing, run with debug logging:
 
 ## Getting Help
 
-- **GitHub Issues:** [github.com/jrc1883/popkit-claude/issues](https://github.com/jrc1883/popkit-claude/issues)
+- **GitHub Issues:** [github.com/jrc1883/popkit-ai/issues](https://github.com/jrc1883/popkit-ai/issues)
 - **Documentation:** [popkit.unjoe.me](https://popkit.unjoe.me)

--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -10,7 +10,7 @@ hero:
       icon: right-arrow
       variant: primary
     - text: View on GitHub
-      link: https://github.com/jrc1883/popkit-claude
+      link: https://github.com/jrc1883/popkit-ai
       icon: external
 ---
 

--- a/packages/popkit-cli/popkit_cli/__init__.py
+++ b/packages/popkit-cli/popkit_cli/__init__.py
@@ -1,3 +1,3 @@
 """PopKit CLI - install, configure, and manage PopKit across AI coding tools."""
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/packages/popkit-cli/popkit_cli/commands/install.py
+++ b/packages/popkit-cli/popkit_cli/commands/install.py
@@ -120,7 +120,7 @@ def run_install(args: argparse.Namespace) -> int:
     if not config_path.exists():
         config_path.write_text(
             "# PopKit Configuration\n"
-            "# See https://github.com/jrc1883/popkit-claude for documentation\n"
+            "# See https://github.com/jrc1883/popkit-ai for documentation\n"
             "\n"
             "version: 2.0\n"
             f"packages_dir: {packages_dir}\n",

--- a/packages/popkit-cli/popkit_cli/commands/update.py
+++ b/packages/popkit-cli/popkit_cli/commands/update.py
@@ -60,7 +60,7 @@ def run_update(args: argparse.Namespace) -> int:
 
     try:
         result = subprocess.run(
-            ["gh", "api", "repos/jrc1883/popkit-claude/releases/latest", "--jq", ".tag_name"],
+            ["gh", "api", "repos/jrc1883/popkit-ai/releases/latest", "--jq", ".tag_name"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -75,6 +75,6 @@ def run_update(args: argparse.Namespace) -> int:
             print("Could not check for updates. Ensure 'gh' CLI is installed.")
     except (FileNotFoundError, subprocess.TimeoutExpired):
         print("GitHub CLI not available. Check releases at:")
-        print("  https://github.com/jrc1883/popkit-claude/releases")
+        print("  https://github.com/jrc1883/popkit-ai/releases")
 
     return 0

--- a/packages/popkit-cli/pyproject.toml
+++ b/packages/popkit-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "popkit-cli"
-version = "1.0.1"
+version = "1.0.2"
 description = "PopKit CLI - install, configure, and manage PopKit across AI coding tools"
 authors = ["Joseph Cannon <joseph@thehouseofdeals.com>"]
 license = "LicenseRef-PolyForm-Noncommercial-1.0.0"
@@ -14,7 +14,7 @@ packages = [{include = "popkit_cli"}]
 [tool.poetry.dependencies]
 python = "^3.11"
 pyyaml = "^6.0"
-popkit-shared = "^1.0.0"
+popkit-shared = "^1.0.2"
 
 [tool.poetry.scripts]
 popkit = "popkit_cli.main:main"

--- a/packages/popkit-core/.claude-plugin/plugin.json
+++ b/packages/popkit-core/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "popkit-core",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "description": "Core utilities plugin - plugin management, project analysis, Power Mode orchestration with Native Swarm & E2B sandboxes, stats, privacy, and meta-features",
   "author": {
     "name": "Joseph Cannon",
     "email": "joseph@thehouseofdeals.com"
   },
   "license": "MIT",
-  "repository": "https://github.com/jrc1883/popkit-claude"
+  "repository": "https://github.com/jrc1883/popkit-ai"
 }

--- a/packages/popkit-core/README.md
+++ b/packages/popkit-core/README.md
@@ -441,7 +441,7 @@ Project sharing levels:
 
 ## Development Status
 
-**Version**: 1.0.0-beta.12
+**Version**: 1.0.0-beta.13
 **Status**: Ready for marketplace publication
 **Epic #580**: Complete - Plugin modularization finished
 

--- a/packages/popkit-core/popkit-package.yaml
+++ b/packages/popkit-core/popkit-package.yaml
@@ -1,5 +1,5 @@
 name: popkit-core
-version: 1.0.0-beta.12
+version: 1.0.0-beta.13
 description: >-
   Core utilities plugin - plugin management, project analysis, Power Mode
   orchestration with Native Swarm & E2B sandboxes, stats, privacy, and meta-features
@@ -7,7 +7,7 @@ author:
   name: Joseph Cannon
   email: joseph@thehouseofdeals.com
 license: MIT
-repository: https://github.com/jrc1883/popkit-claude
+repository: https://github.com/jrc1883/popkit-ai
 
 agents:
   # Tier 1: Always Active

--- a/packages/popkit-dev/.claude-plugin/plugin.json
+++ b/packages/popkit-dev/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "popkit-dev",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "description": "Complete development workflow plugin - feature development, git operations, GitHub management, and daily routines",
   "author": {
     "name": "Joseph Cannon",
     "email": "joseph@thehouseofdeals.com"
   },
   "license": "MIT",
-  "repository": "https://github.com/jrc1883/popkit-claude"
+  "repository": "https://github.com/jrc1883/popkit-ai"
 }

--- a/packages/popkit-dev/README.md
+++ b/packages/popkit-dev/README.md
@@ -1,6 +1,6 @@
 # PopKit Dev - Development Workflow Plugin
 
-**Version:** 1.0.0-beta.12
+**Version:** 1.0.0-beta.13
 **Status:** Ready for marketplace publication (Epic #580 Complete)
 
 ## Overview

--- a/packages/popkit-dev/popkit-package.yaml
+++ b/packages/popkit-dev/popkit-package.yaml
@@ -1,5 +1,5 @@
 name: popkit-dev
-version: 1.0.0-beta.12
+version: 1.0.0-beta.13
 description: >-
   Complete development workflow plugin - feature development, git operations,
   GitHub management, and daily routines
@@ -7,7 +7,7 @@ author:
   name: Joseph Cannon
   email: joseph@thehouseofdeals.com
 license: MIT
-repository: https://github.com/jrc1883/popkit-claude
+repository: https://github.com/jrc1883/popkit-ai
 
 agents:
   # Feature Workflow

--- a/packages/popkit-mcp/popkit_mcp/__init__.py
+++ b/packages/popkit-mcp/popkit_mcp/__init__.py
@@ -1,3 +1,3 @@
 """PopKit MCP Server - exposes PopKit skills, agents, and commands as MCP tools."""
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/packages/popkit-mcp/pyproject.toml
+++ b/packages/popkit-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "popkit-mcp"
-version = "1.0.1"
+version = "1.0.2"
 description = "PopKit MCP Server - exposes skills, agents, and commands as MCP tools"
 authors = ["Joseph Cannon <joseph@thehouseofdeals.com>"]
 license = "LicenseRef-PolyForm-Noncommercial-1.0.0"
@@ -20,14 +20,14 @@ classifiers = [
 ]
 
 [tool.poetry.urls]
-"Homepage" = "https://github.com/jrc1883/popkit-claude"
-"Repository" = "https://github.com/jrc1883/popkit-claude"
+"Homepage" = "https://github.com/jrc1883/popkit-ai"
+"Repository" = "https://github.com/jrc1883/popkit-ai"
 
 [tool.poetry.dependencies]
 python = "^3.11"
 mcp = "^1.12.0"
 pyyaml = "^6.0"
-popkit-shared = {version = "^1.0.0", optional = true}
+popkit-shared = {version = "^1.0.2", optional = true}
 
 [tool.poetry.extras]
 full = ["popkit-shared"]

--- a/packages/popkit-ops/.claude-plugin/plugin.json
+++ b/packages/popkit-ops/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "popkit-ops",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "description": "PopKit operations plugin - quality assurance, deployment, and debugging workflows",
   "author": {
     "name": "Joseph Cannon",
     "email": "joseph@thehouseofdeals.com"
   },
   "license": "MIT",
-  "repository": "https://github.com/jrc1883/popkit-claude"
+  "repository": "https://github.com/jrc1883/popkit-ai"
 }

--- a/packages/popkit-ops/README.md
+++ b/packages/popkit-ops/README.md
@@ -1,6 +1,6 @@
 # PopKit - Operations Plugin
 
-**Version:** 1.0.0-beta.12
+**Version:** 1.0.0-beta.13
 **Status:** Operations Plugin (Ready for marketplace)
 
 ## Overview

--- a/packages/popkit-ops/popkit-package.yaml
+++ b/packages/popkit-ops/popkit-package.yaml
@@ -1,12 +1,12 @@
 name: popkit-ops
-version: 1.0.0-beta.12
+version: 1.0.0-beta.13
 description: >-
   PopKit operations plugin - quality assurance, deployment, and debugging workflows
 author:
   name: Joseph Cannon
   email: joseph@thehouseofdeals.com
 license: MIT
-repository: https://github.com/jrc1883/popkit-claude
+repository: https://github.com/jrc1883/popkit-ai
 
 agents:
   # Tier 1: Always Active

--- a/packages/popkit-research/.claude-plugin/plugin.json
+++ b/packages/popkit-research/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "popkit-research",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "description": "PopKit research plugin - knowledge management and research workflows",
   "author": {
     "name": "Joseph Cannon",
     "email": "joseph@thehouseofdeals.com"
   },
   "license": "MIT",
-  "repository": "https://github.com/jrc1883/popkit-claude"
+  "repository": "https://github.com/jrc1883/popkit-ai"
 }

--- a/packages/popkit-research/README.md
+++ b/packages/popkit-research/README.md
@@ -1,6 +1,6 @@
 # PopKit - Research Plugin
 
-**Version:** 1.0.0-beta.12
+**Version:** 1.0.0-beta.13
 **Status:** Research Plugin (Ready for marketplace)
 
 ## Overview

--- a/packages/popkit-research/popkit-package.yaml
+++ b/packages/popkit-research/popkit-package.yaml
@@ -1,12 +1,12 @@
 name: popkit-research
-version: 1.0.0-beta.12
+version: 1.0.0-beta.13
 description: >-
   PopKit research plugin - knowledge management and research workflows
 author:
   name: Joseph Cannon
   email: joseph@thehouseofdeals.com
 license: MIT
-repository: https://github.com/jrc1883/popkit-claude
+repository: https://github.com/jrc1883/popkit-ai
 
 agents:
   - path: agents/tier-2-on-demand/researcher

--- a/packages/shared-py/popkit_shared/__init__.py
+++ b/packages/shared-py/popkit_shared/__init__.py
@@ -1,3 +1,3 @@
 """PopKit Shared - Foundation utilities for PopKit plugin ecosystem."""
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/packages/shared-py/pyproject.toml
+++ b/packages/shared-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "popkit-shared"
-version = "1.0.1"
+version = "1.0.2"
 description = "Shared utilities for PopKit plugin ecosystem"
 authors = ["Joseph Cannon <joseph@thehouseofdeals.com>"]
 license = "LicenseRef-PolyForm-Noncommercial-1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "popkit"
-version = "1.0.1"
+version = "1.0.2"
 description = "PopKit - LLM-agnostic developer orchestration engine"
 authors = ["Joseph Cannon <joseph@thehouseofdeals.com>"]
 license = "LicenseRef-PolyForm-Noncommercial-1.0.0"
@@ -20,14 +20,14 @@ classifiers = [
 ]
 
 [tool.poetry.urls]
-"Homepage" = "https://github.com/jrc1883/popkit-claude"
-"Repository" = "https://github.com/jrc1883/popkit-claude"
+"Homepage" = "https://github.com/jrc1883/popkit-ai"
+"Repository" = "https://github.com/jrc1883/popkit-ai"
 
 [tool.poetry.dependencies]
 python = "^3.11"
-popkit-shared = "^1.0.0"
-popkit-cli = "^1.0.0"
-popkit-mcp = {version = "^1.0.0", optional = true}
+popkit-shared = "^1.0.2"
+popkit-cli = "^1.0.2"
+popkit-mcp = {version = "^1.0.2", optional = true}
 pyyaml = "^6.0"
 filelock = "^3.13.0"
 lxml = {version = "^6.0", optional = true}


### PR DESCRIPTION
## Summary

- bump Claude Code marketplace/plugin manifests to `1.0.0-beta.13`
- prepare PyPI package metadata for `popkit`, `popkit-shared`, `popkit-cli`, and `popkit-mcp` `1.0.2`
- point install/update/release docs and workflows at the current `jrc1883/popkit-ai` repo while preserving the existing `popkit-claude` marketplace name for compatibility
- strengthen marketplace validation so future release drift is caught in CI

## Validation

- `python .github/scripts/validate_marketplace.py`
- `npm run lint`
- `npm run lint:json`
- `npm run lint:md`
- `npm run docs:build`
- `ruff check .github/scripts/validate_marketplace.py packages/popkit-cli/popkit_cli/__init__.py packages/popkit-cli/popkit_cli/commands/install.py packages/popkit-cli/popkit_cli/commands/update.py packages/popkit-mcp/popkit_mcp/__init__.py packages/shared-py/popkit_shared/__init__.py --config packages/shared-py/pyproject.toml`
- `python -m build` + `twine check` for `packages/shared-py`, `packages/popkit-cli`, `packages/popkit-mcp`, and root `popkit`

## Notes

- Public GitHub Releases and PyPI still need publishing after merge; this PR prepares the source metadata and release automation.