### PR TITLE
chore(ci): isolate release workflows from self-hosted runner

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -29,7 +29,7 @@ jobs:
 
   label-issues:
     name: Label Issues
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: github.event_name == 'issues'
 
     steps:
@@ -119,7 +119,7 @@ jobs:
 
   label-prs:
     name: Label PRs
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
   plugin-validate:
     name: Validate Plugins
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -107,7 +107,7 @@ jobs:
 
   agents-validate:
     name: Validate Agents
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -138,7 +138,7 @@ jobs:
 
   hooks-validate:
     name: Validate Hooks
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -184,7 +184,7 @@ jobs:
 
   ci-complete:
     name: CI Complete
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs:
       - plugin-validate
       - agents-validate

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -43,7 +43,7 @@ jobs:
 
   build:
     name: Build Documentation
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -95,7 +95,7 @@ jobs:
 
   deploy:
     name: Deploy to Cloudflare Pages
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
@@ -151,7 +151,7 @@ jobs:
 
   preview:
     name: Deploy Preview
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'pull_request'
     permissions:

--- a/.github/workflows/enhanced-ci.yml
+++ b/.github/workflows/enhanced-ci.yml
@@ -54,7 +54,7 @@ jobs:
 
   json-syntax-validation:
     name: JSON Syntax Validation
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -80,7 +80,7 @@ jobs:
 
   plugin-manifest-validation:
     name: Plugin Manifest Validation
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: json-syntax-validation
 
     steps:
@@ -107,7 +107,7 @@ jobs:
 
   marketplace-validation:
     name: Marketplace Validation
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: plugin-manifest-validation
 
     steps:
@@ -132,7 +132,7 @@ jobs:
 
   cross-plugin-validation:
     name: Cross-Plugin Validation
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: plugin-manifest-validation
 
     steps:
@@ -150,7 +150,7 @@ jobs:
 
   hooks-validation:
     name: Hooks Validation
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -200,7 +200,7 @@ jobs:
 
   security-checks:
     name: Security Checks
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -241,7 +241,7 @@ jobs:
 
   documentation-checks:
     name: Documentation Checks
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -284,7 +284,7 @@ jobs:
 
   plugin-tests:
     name: Plugin Test Suite
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [plugin-manifest-validation]
 
     steps:
@@ -315,7 +315,7 @@ jobs:
 
   ci-complete:
     name: CI Complete
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs:
       - json-syntax-validation
       - plugin-manifest-validation

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   greeting:
     name: Greet First-Time Contributors
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Greet first-time contributors

--- a/.github/workflows/ip-scan.yml
+++ b/.github/workflows/ip-scan.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   ip-scan:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     name: Scan for IP Leaks
     permissions:
       contents: read

--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -50,7 +50,7 @@ concurrency:
 jobs:
   publish:
     name: Publish to Public Repo
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout monorepo (full history)

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   update-release-draft:
     name: Update Release Draft
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Draft release notes

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   stale:
     name: Mark Stale Issues
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Handle stale issues

--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   sync:
     name: Update README Auto-Gen Sections
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   python-tests:
     name: Python Tests (Python ${{ matrix.python-version }})
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
@@ -73,7 +73,7 @@ jobs:
 
   typescript-tests:
     name: TypeScript Tests (Node ${{ matrix.node-version }})
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
@@ -112,7 +112,7 @@ jobs:
 
   docs-build:
     name: Documentation Build Test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- move release, docs, CodeQL, and lightweight admin workflows from the single self-hosted runner to GitHub-hosted Ubuntu runners
- keep heavier CI/test/benchmark workflows on self-hosted for a separate audit
- reduce the chance that PyPI/plugin publishing is blocked by Dependabot or docs queue work

## Validation
- `git diff --check`
- `actionlint -color=false` on the changed workflow files via WSL

## Notes
This follows the release incident from the `v1.0.0-beta.13` / PyPI `1.0.2` publish, where the self-hosted runner queue delayed the manual publish workflow.
