### PR TITLE
fix(morning): use npm outdated for mixed repos

### DIFF
--- a/packages/shared-py/popkit_shared/utils/generic_project_detector.py
+++ b/packages/shared-py/popkit_shared/utils/generic_project_detector.py
@@ -133,6 +133,19 @@ class GenericProjectDetector:
         # Python
         elif language == "Python":
             pm = package_manager or "pip"
+            if pm in ("npm", "pnpm", "yarn"):
+                check_installed = f"{pm} list --depth=0"
+                check_outdated = f"{pm} outdated"
+                install_command = f"{pm} install"
+            elif pm == "pip":
+                check_installed = "pip freeze"
+                check_outdated = "pip list --outdated"
+                install_command = "pip install -r requirements.txt"
+            else:
+                check_installed = f"{pm} list"
+                check_outdated = f"{pm} show --outdated"
+                install_command = f"{pm} install"
+
             return ProjectType(
                 primary_language=language,
                 package_manager=pm,
@@ -144,11 +157,9 @@ class GenericProjectDetector:
                     {"name": "api", "port": 8000, "description": "Python API server"},
                     {"name": "database", "port": 5432, "description": "PostgreSQL"},
                 ],
-                check_installed=f"{pm} freeze" if pm == "pip" else f"{pm} list",
-                check_outdated=f"{pm} list --outdated" if pm == "pip" else f"{pm} show --outdated",
-                install_command=f"{pm} install -r requirements.txt"
-                if pm == "pip"
-                else f"{pm} install",
+                check_installed=check_installed,
+                check_outdated=check_outdated,
+                install_command=install_command,
             )
 
         # Rust

--- a/packages/shared-py/popkit_shared/utils/project_config.py
+++ b/packages/shared-py/popkit_shared/utils/project_config.py
@@ -146,6 +146,7 @@ class ProjectConfig:
 
         # Merge overrides into project type
         merged = {**project_type_data, **overrides}
+        self._normalize_cached_commands(merged)
 
         try:
             return ProjectType(
@@ -163,6 +164,18 @@ class ProjectConfig:
         except TypeError as e:
             print(f"[WARN] Failed to build ProjectType from cache: {e}")
             return None
+
+    def _normalize_cached_commands(self, project_type_data: dict[str, Any]) -> None:
+        """Patch known-bad cached command shapes from older detector versions."""
+        package_manager = project_type_data.get("package_manager")
+        if package_manager not in {"npm", "pnpm", "yarn"}:
+            return
+
+        if project_type_data.get("check_installed") == f"{package_manager} list":
+            project_type_data["check_installed"] = f"{package_manager} list --depth=0"
+
+        if project_type_data.get("check_outdated") == f"{package_manager} show --outdated":
+            project_type_data["check_outdated"] = f"{package_manager} outdated"
 
     def cache_project_type(self, project_type: ProjectType) -> bool:
         """

--- a/packages/shared-py/tests/utils/test_project_detection_commands.py
+++ b/packages/shared-py/tests/utils/test_project_detection_commands.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Tests for project detector dependency command selection."""
+
+from popkit_shared.utils.generic_project_detector import GenericProjectDetector
+from popkit_shared.utils.project_config import ProjectConfig
+
+
+def test_python_repo_with_npm_package_manager_uses_npm_outdated():
+    """Mixed Python/Node repos should not use `npm show --outdated`."""
+    detector = GenericProjectDetector(".")
+
+    project_type = detector._build_project_type(
+        "Python",
+        "npm",
+        "pytest",
+        None,
+        "ruff",
+        "prettier",
+    )
+
+    assert project_type.check_installed == "npm list --depth=0"
+    assert project_type.check_outdated == "npm outdated"
+    assert project_type.install_command == "npm install"
+
+
+def test_cached_npm_show_outdated_command_is_normalized(tmp_path):
+    """Older .popkit/project.json caches should not preserve bad npm commands."""
+    config_dir = tmp_path / ".popkit"
+    config_dir.mkdir()
+    config_path = config_dir / "project.json"
+    config_path.write_text(
+        """
+{
+  "version": "1.0",
+  "detected_at": "2999-01-01T00:00:00",
+  "project_type": {
+    "language": "Python",
+    "package_manager": "npm",
+    "test_framework": "pytest",
+    "build_tool": null,
+    "linter": "ruff",
+    "formatter": "prettier",
+    "check_installed": "npm list",
+    "check_outdated": "npm show --outdated",
+    "install_command": "npm install"
+  },
+  "auto_detect": true,
+  "cache_ttl_hours": 24,
+  "overrides": {}
+}
+""".strip()
+    )
+
+    project_type = ProjectConfig(str(tmp_path)).get_cached_project_type()
+
+    assert project_type is not None
+    assert project_type.check_installed == "npm list --depth=0"
+    assert project_type.check_outdated == "npm outdated"


### PR DESCRIPTION
## Summary
- use `npm outdated` instead of `npm show --outdated` when a Python-primary mixed repo is using npm as its package manager
- normalize older `.popkit/project.json` caches so stale `npm show --outdated` commands do not keep producing false health warnings
- add regression coverage for mixed Python/npm detection and cached command normalization

## Validation
- `python -m pytest packages/shared-py/tests/utils/test_project_detection_commands.py -q`
- `ruff check packages/shared-py/popkit_shared/utils/generic_project_detector.py packages/shared-py/popkit_shared/utils/project_config.py packages/shared-py/tests/utils/test_project_detection_commands.py --config packages/shared-py/pyproject.toml`
- `ruff format --check packages/shared-py/popkit_shared/utils/generic_project_detector.py packages/shared-py/popkit_shared/utils/project_config.py packages/shared-py/tests/utils/test_project_detection_commands.py --config packages/shared-py/pyproject.toml`
- `python "C:\Users\Josep\popkit-claude\packages\popkit-dev\skills\pop-morning\scripts\morning_workflow.py" --profile standard --quick`
- `npm outdated --json`
- `npm audit --json`
- `git diff --check`
